### PR TITLE
Add github-stars-badge to feature polyfills

### DIFF
--- a/tasks/start-template.html
+++ b/tasks/start-template.html
@@ -74,6 +74,9 @@
 						<ul class="cssdb-feature-polyfill-list">${feature.polyfills.map(
 							polyfill => `<li class="cssdb-feature-polyfill-item">
 								<a class="cssdb-feature-polyfill-link" href="${polyfill.link}">${polyfill.type}</a>
+								<span class="cssdb-feature-polyfill-stars-minimal">
+									<a href="${polyfill.link+'/stargazers'}"><img alt="GitHub stars" src="https://img.shields.io/github/stars/${polyfill.link.split('/').slice(3,5).join('/')}.svg?style=social"></a>
+								</span>
 							</li>`
 						)}</ul>
 					</div>`

--- a/tasks/style-template.css
+++ b/tasks/style-template.css
@@ -285,6 +285,30 @@ img {
 	}
 }
 
+.cssdb-feature-polyfill-item {
+	display: flex;
+	height: 20px;
+	margin-block-end: 7px;
+
+	& .cssdb-feature-polyfill-stars {
+		margin-inline-start: 3px;
+
+		& img {
+			height: 20px;
+		}
+	}
+
+	& .cssdb-feature-polyfill-stars-minimal {
+		margin-inline-start: 3px;
+		overflow: hidden;
+
+		& img {
+			height: 20px;
+			transform: translateX(-58px);
+		}
+	}
+}
+
 /* Examples
 /* ========================================================================== */
 


### PR DESCRIPTION
As I was scrolling this sweet website yesterday I thought that it would be nice to have the ability to `like` the feature entries and see the demand from the community (maybe a `facebook like button` per anchored `href` or some small `google sheets` "db"). But then I realized that we already have even better data stream about css feature demand that is a Github stars badge for each polyfill which also has added benefit to encourage the user to check out the repo (at least for me, no matter the repo popularity O_o).

Anyways, here's my PR for the feature and of course feel free to change anything if you consider merging it!

- `shields.io` svg url is created inside HTML template and since we don't have Gitlab (or other) repos yet I didn't complicate the parsing.
- badge embedding comes in two flavours, the usual social svg `.cssdb-feature-polyfill-stars` and `.cssdb-feature-polyfill-stars-minimal` (personal preference). I assume you'll choose one of them and remove the other. Screenshot of the two is bellow. 
- badges are wrapped with `/stargazers` anchor to add more functionality 

Here's a demo: https://georgegach.github.io/cssdb/

Here's a screenshot: ![Screenshot from 2019-07-23 09-36-50](https://user-images.githubusercontent.com/5983539/61718220-869d4500-ad30-11e9-9a4b-2067238aea25.png)
