### PR TITLE
Remove overlap

### DIFF
--- a/tasks/style-template.css
+++ b/tasks/style-template.css
@@ -221,7 +221,7 @@ img {
 	display: flex;
 	font-size: 87.5%;
 	font-weight: 700;
-	margin-block: 0 -22.5px;
+	margin-block: 0 -10.5px;
 	padding-inline: 15px;
 	position: relative;
 	text-transform: uppercase;


### PR DESCRIPTION
This should fix a small styling issue.

Before:
![overlap](https://user-images.githubusercontent.com/8074468/90296109-98451380-de82-11ea-95c4-2f85a8bc0695.png)
After:
![nooverlap](https://user-images.githubusercontent.com/8074468/90296127-9f6c2180-de82-11ea-9035-2ce1b202c72c.png)

