### PR TITLE
Update links to use HTTPS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,7 @@ beginner-friendly instructions.
 
 ### Why are we doing this?
 
-The CSSWG doesn’t follow the [TC39 process]. How they operate [in theory](https://www.w3.org/Style/CSS/specs.en.html) versus [in real life](http://fantasai.inkedblade.net/weblog/2011/inside-csswg/) is unclear, and
+The CSSWG doesn’t follow the [TC39 process]. How they operate [in theory](https://www.w3.org/Style/CSS/specs.en.html) versus [in real life](https://fantasai.inkedblade.net/weblog/2011/inside-csswg/) is unclear, and
 browsers
 [don’t necessarily follow their process anyway](https://www.chromestatus.com/feature/5753701012602880),
 so we have to discern what’s really going on ourselves. If we didn’t, we

--- a/README.md
+++ b/README.md
@@ -30,6 +30,6 @@ is desired.
 [cli-url]: https://travis-ci.org/csstools/cssdb
 [cssdb]: https://github.com/csstools/cssdb
 [CSSWG]: https://wiki.csswg.org/spec
-[inside view of the CSSWG]: http://fantasai.inkedblade.net/weblog/2011/inside-csswg/process
+[inside view of the CSSWG]: https://fantasai.inkedblade.net/weblog/2011/inside-csswg/process
 [npm-img]: https://img.shields.io/npm/v/cssdb.svg
 [npm-url]: https://www.npmjs.com/package/cssdb

--- a/STAGES.md
+++ b/STAGES.md
@@ -101,7 +101,7 @@ interested parties are identified and incorporated into the proposal.
 
 [championed]: #what-is-a-champion
 [hosted]: #what-is-a-champion
-[inside view of the CSSWG]: http://fantasai.inkedblade.net/weblog/2011/inside-csswg/process
+[inside view of the CSSWG]: https://fantasai.inkedblade.net/weblog/2011/inside-csswg/process
 [recognized browser vendors]: #recognized-browser-vendors
 [W3C]: https://www.w3.org/
 [W3C Working Group]: https://wiki.csswg.org/spec


### PR DESCRIPTION
I've tested the links, they still work - HTTP was redirected to HTTPS already:
- https://fantasai.inkedblade.net/weblog/2011/inside-csswg/
- https://fantasai.inkedblade.net/weblog/2011/inside-csswg/process

But encourage HTTPS just a bit more :)