### PR TITLE
Split about and support information in features

### DIFF
--- a/src/components/caniuse-feature.astro
+++ b/src/components/caniuse-feature.astro
@@ -11,7 +11,7 @@ const browsers = {
 	'and_qq': 'QQ Browserr',
 };
 ---
-{ feature.browser_support && (
+{ feature.browser_support && Object.keys(feature.browser_support).length > 0 && (
 <a
 		class="cssdb-feature-caniuse"
 		href={link}

--- a/src/components/feature-polyfill.astro
+++ b/src/components/feature-polyfill.astro
@@ -46,9 +46,6 @@ const isBundled = presetEnvPlugins.includes(id);
 		{polyfill.type}
 		<span class="sr-only">for {title}</span>
 	</a>
-	{(polyfill.type === "PostCSS Plugin" && isBundled) &&  (
-		<span> (bundled with <a class="cssdb-feature-polyfill-link" href="https://github.com/csstools/postcss-plugins/blob/main/plugin-packs/postcss-preset-env">Preset Env</a>)</span>
-	)}
 	{isGithub && (
 		<span class="cssdb-feature-polyfill-stars-minimal">
 			<a href={`${repoUrl}/stargazers`}>
@@ -58,4 +55,7 @@ const isBundled = presetEnvPlugins.includes(id);
 			</a>
 		</span>
 	)}
+	{(polyfill.type === "PostCSS Plugin" && isBundled) &&  (
+		<span> (bundled with <a class="cssdb-feature-polyfill-link" href="https://github.com/csstools/postcss-plugins/blob/main/plugin-packs/postcss-preset-env">Preset Env</a>)</span>
+	)}	
 </li>

--- a/src/components/feature-polyfill.astro
+++ b/src/components/feature-polyfill.astro
@@ -1,8 +1,44 @@
 ---
-const { polyfill, title } = Astro.props;
+const { polyfill, id, title } = Astro.props;
 const repoUrl = polyfill.link.includes('csstools/postcss-plugins') ? 'https://github.com/csstools/postcss-plugins' : polyfill.link;
 const starImage = `https://img.shields.io/github/stars/${polyfill.link.split('/').slice(3,5).join('/')}.svg?style=social`;
 const isGithub = repoUrl.includes('github.com');
+const presetEnvPlugins = [
+	'all-property',
+	'any-link-pseudo-class',
+	'blank-pseudo-class',
+	'break-properties',
+	'case-insensitive-attributes',
+	'clamp',
+	'color-functional-notation',
+	'custom-media-queries',
+	'custom-properties',
+	'custom-selectors',
+	'dir-pseudo-class',
+	'display-two-values',
+	'double-position-gradients',
+	'environment-variables',
+	'focus-visible-pseudo-class',
+	'focus-within-pseudo-class',
+	'font-format-keywords',
+	'font-variant-property',
+	'gap-properties',
+	'has-pseudo-class',
+	'hexadecimal-alpha-notation',
+	'image-set-function',
+	'lab-function',
+	'logical-properties-and-values',
+	'media-query-ranges',
+	'nesting-rules',
+	'not-pseudo-class',
+	'overflow-property',
+	'overflow-wrap-property',
+	'place-properties',
+	'prefers-color-scheme-query',
+	'rebeccapurple-color',
+	'system-ui-font-family',
+];
+const isBundled = presetEnvPlugins.includes(id);
 ---
 
 <li class="cssdb-feature-polyfill-item">
@@ -10,6 +46,9 @@ const isGithub = repoUrl.includes('github.com');
 		{polyfill.type}
 		<span class="sr-only">for {title}</span>
 	</a>
+	{(polyfill.type === "PostCSS Plugin" && isBundled) &&  (
+		<span> (bundled with <a class="cssdb-feature-polyfill-link" href="https://github.com/csstools/postcss-plugins/blob/main/plugin-packs/postcss-preset-env">Preset Env</a>)</span>
+	)}
 	{isGithub && (
 		<span class="cssdb-feature-polyfill-stars-minimal">
 			<a href={`${repoUrl}/stargazers`}>

--- a/src/components/feature-polyfills.astro
+++ b/src/components/feature-polyfills.astro
@@ -8,7 +8,7 @@ const polyfills = Astro.props.polyfills && Astro.props.polyfills.length ? Astro.
 	Use with a
 
 	<ul class="cssdb-feature-polyfill-list">{polyfills.map(polyfill => (
-		<FeaturePolyfill polyfill={polyfill} title={Astro.props.title} />
+		<FeaturePolyfill polyfill={polyfill} id={Astro.props.id} title={Astro.props.title} />
 	))}</ul>
 </div>
 ) : ''}

--- a/src/components/feature.astro
+++ b/src/components/feature.astro
@@ -5,7 +5,6 @@ import { parseExample }  from '../../utils/feature-example.js';
 
 const { feature } = Astro.props;
 const imageName = `/images/stages/stage-${feature.stage}.svg`;
-const badge = `/images/badges/${feature.id}.svg`;
 
 const [title, description] = await Promise.all([
 	Astro.privateRenderMarkdownDoNotUse(feature.title),
@@ -16,42 +15,6 @@ const simpleTitle = title.replace('<p>', '').replace('</p>', '');
 const cleanTitle = simpleTitle.replace(/<\/?[^>]+(>|$)/g, '');
 const simpleDescription = description.replace('<p>', '').replace('</p>', '');
 
-const mdnLogo = 'https://shields.io/badge/docs-black?logo=mozilla&style=flat-square';
-const presetEnvPlugins = [
-	'all-property',
-	'any-link-pseudo-class',
-	'blank-pseudo-class',
-	'break-properties',
-	'case-insensitive-attributes',
-	'clamp',
-	'color-functional-notation',
-	'custom-media-queries',
-	'custom-properties',
-	'custom-selectors',
-	'dir-pseudo-class',
-	'display-two-values',
-	'double-position-gradients',
-	'environment-variables',
-	'focus-visible-pseudo-class',
-	'focus-within-pseudo-class',
-	'font-format-keywords',
-	'font-variant-property',
-	'gap-properties',
-	'has-pseudo-class',
-	'hexadecimal-alpha-notation',
-	'image-set-function',
-	'lab-function',
-	'logical-properties-and-values',
-	'media-query-ranges',
-	'nesting-rules',
-	'not-pseudo-class',
-	'overflow-property',
-	'overflow-wrap-property',
-	'place-properties',
-	'prefers-color-scheme-query',
-	'rebeccapurple-color',
-	'system-ui-font-family',
-];
 const stages = [
 	'stage-0-aspirational',
 	'stage-1-experimental',
@@ -59,81 +22,37 @@ const stages = [
 	'stage-3-embraced',
 	'stage-4-standardized',
 ]
-const isBundled = presetEnvPlugins.includes(feature.id);
 ---
-<section class="cssdb-feature" id={feature.id}>
+<article class="cssdb-feature" id={feature.id}>
 	<header class="cssdb-feature-header">
-		<img class="cssdb-feature-stage" src={imageName} alt="" width="62" height="62" role="presentation" loading="lazy">
-		<div class="cssdb-feature-header-content">
-			<h2 class="cssdb-feature-heading">
-				<a href={`#${feature.id}`}>{simpleTitle}</a>
-			</h2>
-			<p class="cssdb-feature-description">
-				{simpleDescription}
-			</p>
-		</div>
-	</header>
-	<div class="cssdb-feature-content">
-		<p class="cssdb-feature-specification">
-			<a
-					class="cssdb-feature-specification-link"
-					href={feature.specification}
-					aria-label={`Specification for ${cleanTitle}`}
-			>
-				Specification
-			</a>
-			{feature.docs?.mdn && (
-			<a
-					class="cssdb-feature-mdn-badge-link"
-					href={feature.docs.mdn}
-					aria-label={`Documentation for ${cleanTitle}`}
-					target="_blank"
-					rel="noreferrer"
-			>
-				<img
-						class="cssdb-feature-mdn-badge"
-						src={mdnLogo}
-						alt="Mozilla Developer Network Documentation"
-						loading="lazy"
-						decoding="async"
-						width="53"
-						height="20"
-				>
-			</a>
-			)}
-			<a class="cssdb-feature-specification-badge-link" href={`#${stages[feature.stage]}`}>
-				<img
-						class="cssdb-feature-specification-badge"
-						src={badge}
-						alt={`Stage ${feature.stage}`}
-						loading="lazy"
-						decoding="async"
-						width="94"
-						height="20"
-				/>
-			</a>
-			{isBundled && (
-			<a
-					class="cssdb-feature-mdn-badge-link"
-					href="https://github.com/csstools/postcss-plugins/blob/main/plugin-packs/postcss-preset-env"
-					aria-label={`${cleanTitle} is bundled with PostCSS Preset Env`}
-					target="_blank"
-					rel="noreferrer"
-			>
-				<img
-						class="cssdb-feature-mdn-badge"
-						src="https://img.shields.io/badge/Bundled%20with-PostCSS%20Preset%20Env-brightgreen?style=flat-square"
-						alt=""
-						loading="lazy"
-						decoding="async"
-						width="200"
-						height="20"
-				>
-			</a>
-			)}
+		<a class="cssdb-feature-stage" href={`#${stages[feature.stage]}`}>
+			<img class="cssdb-feature-stage-image" src={imageName} alt="" width="62" height="62" role="presentation" loading="lazy">
+		</a>
+		<h2 class="cssdb-feature-heading">
+			<a href={`#${feature.id}`}>{simpleTitle}</a>
+		</h2>
+		<p class="cssdb-feature-description">
+			{simpleDescription}
 		</p>
-		<pre class="cssdb-feature-example" dir="ltr">{ parseExample(feature.example) }</pre>
-		<CaniuseFeature feature={feature} title={cleanTitle} />
-		<FeaturePolyfills polyfills={feature.polyfills} title={cleanTitle} />
-	</div>
-</section>
+	</header>
+	<pre class="cssdb-feature-example" dir="ltr">{ parseExample(feature.example) }</pre>
+	<p class="cssdb-feature-docs">
+		<a class="cssdb-feature-docs-link" href={feature.specification}>
+			Specification <span class="sr-only">for ${cleanTitle}</span>
+		</a>
+
+		{feature.docs?.mdn && (
+			<>
+				and <a class="cssdb-feature-docs-link"
+					href={feature.docs.mdn}
+					target="_blank"
+					rel="noreferrer"
+				>
+					MDN documentation <span class="sr-only">for ${cleanTitle}</span>
+				</a>
+			</>
+		)}
+	</p>
+	<CaniuseFeature feature={feature} title={cleanTitle} />
+	<FeaturePolyfills polyfills={feature.polyfills} id={feature.id} title={cleanTitle} />
+</article>

--- a/src/components/feature.astro
+++ b/src/components/feature.astro
@@ -5,6 +5,7 @@ import { parseExample }  from '../../utils/feature-example.js';
 
 const { feature } = Astro.props;
 const imageName = `/images/stages/stage-${feature.stage}.svg`;
+const badge = `/images/badges/${feature.id}.svg`;
 
 const [title, description] = await Promise.all([
 	Astro.privateRenderMarkdownDoNotUse(feature.title),
@@ -35,24 +36,49 @@ const stages = [
 			{simpleDescription}
 		</p>
 	</header>
-	<pre class="cssdb-feature-example" dir="ltr">{ parseExample(feature.example) }</pre>
 	<p class="cssdb-feature-docs">
-		<a class="cssdb-feature-docs-link" href={feature.specification}>
-			Specification <span class="sr-only">for ${cleanTitle}</span>
+		<a
+			href={feature.specification}
+			aria-label={`Specification for ${cleanTitle}`}
+		>
+			<img
+				src="https://img.shields.io/badge/Spec-005A9C?logo=w3c&style=flat-square"
+				alt="W3C Specification"
+				loading="lazy"
+				decoding="async"
+				width="55"
+				height="20"
+			>
 		</a>
-
 		{feature.docs?.mdn && (
-			<>
-				and <a class="cssdb-feature-docs-link"
-					href={feature.docs.mdn}
-					target="_blank"
-					rel="noreferrer"
+			<a
+				href={feature.docs.mdn}
+				aria-label={`Documentation for ${cleanTitle}`}
+				target="_blank"
+				rel="noreferrer"
+			>
+				<img
+					src="https://shields.io/badge/docs-black?logo=mozilla&style=flat-square"
+					alt="Mozilla Developer Network Documentation"
+					loading="lazy"
+					decoding="async"
+					width="53"
+					height="20"
 				>
-					MDN documentation <span class="sr-only">for ${cleanTitle}</span>
-				</a>
-			</>
+			</a>
 		)}
+		<a href={`#${stages[feature.stage]}`}>
+			<img
+				src={badge}
+				alt={`Stage ${feature.stage}`}
+				loading="lazy"
+				decoding="async"
+				width="94"
+				height="20"
+			/>
+		</a>
 	</p>
+	<pre class="cssdb-feature-example" dir="ltr">{ parseExample(feature.example) }</pre>
 	<CaniuseFeature feature={feature} title={cleanTitle} />
 	<FeaturePolyfills polyfills={feature.polyfills} id={feature.id} title={cleanTitle} />
 </article>

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -193,28 +193,31 @@ img {
 /* ========================================================================== */
 
 .cssdb-feature {
-	margin-block-start: 100px;
+	margin-block-start: 80px;
 }
 
 .cssdb-feature-header {
-	display: flex;
-
-	& > * {
-		display: inline-block;
-		vertical-align: top;
-	}
+	display: grid;
+	gap: 5px 20px;
+	grid:
+		"stage title"
+		"stage description"
+		/ 62px auto;
 }
 
 .cssdb-feature-stage {
-	flex-shrink: 0;
+	grid-area: stage;
+}
+
+.cssdb-feature-stage-image {
 	height: 62px;
-	margin-block-end: 20px;
-	margin-inline-end: 15px;
 	width: 62px;
+	display: block;
 }
 
 .cssdb-feature-heading {
 	font-size: 1.17em;
+	grid-area: title;
 	margin: 0;
 
 	& a {
@@ -223,49 +226,24 @@ img {
 }
 
 .cssdb-feature-description {
-	display: inline-block;
-	margin-block: 5px 25px;
+	grid-area: description;
+	margin: 0;
 }
 
-.cssdb-feature-specification {
-	display: flex;
-	flex-wrap: wrap;
+.cssdb-feature-docs {
 	font-size: 87.5%;
+}
+
+.cssdb-feature-docs-link {
 	font-weight: 700;
-	margin-block: 0 -10.5px;
-	padding-inline: 15px;
-	position: relative;
 	text-transform: uppercase;
-
-	& > :not(:last-child) {
-		margin-inline-end: .25em;
-	}
-}
-
-.cssdb-feature-specification-link {
-	background-image: linear-gradient(currentColor 25%, transparent 50%);
-	background-position: 200% 100%;
-	background-repeat: no-repeat;
-	background-size: 200% 2px;
-	padding-block-end: 2px;
-	transition: background-position 250ms;
-
-	&:hover {
-		background-position: 100% 100%;
-	}
-}
-
-.cssdb-feature-mdn-badge,
-.cssdb-feature-specification-badge {
-	height: 20px;
-	vertical-align: top;
 }
 
 .cssdb-feature-polyfills {
 	display: flex;
+	flex-wrap: wrap;
 	font-size: 87.5%;
-	margin-block-end: -24px;
-	padding-inline: 15px;
+	margin-top: 5px;
 
 	&:dir(rtl) {
 		flex-direction: column;
@@ -273,11 +251,9 @@ img {
 }
 
 .cssdb-feature-polyfill-list {
-	font-weight: 700;
 	list-style: none;
 	margin: 0;
 	padding: 0;
-	text-transform: uppercase;
 
 	&:dir(ltr) {
 		margin-left: .5em;
@@ -285,6 +261,8 @@ img {
 }
 
 .cssdb-feature-polyfill-link {
+	font-weight: 700;
+	text-transform: uppercase;
 	background-image: linear-gradient(currentColor 25%, transparent 50%);
 	background-position: 200% 100%;
 	background-repeat: no-repeat;
@@ -299,8 +277,9 @@ img {
 
 .cssdb-feature-polyfill-item {
 	display: flex;
-	height: 20px;
+	flex-wrap: wrap;
 	margin-block-end: 7px;
+	column-gap: 5px;
 
 	& .cssdb-feature-polyfill-stars {
 		margin-inline-start: 3px;
@@ -313,12 +292,17 @@ img {
 	& .cssdb-feature-polyfill-stars-minimal {
 		margin-inline-start: 3px;
 		overflow: hidden;
+		inline-size: 32px;
 
 		& img {
 			height: 20px;
 			transform: translateX(-58px);
 		}
 	}
+}
+
+.cssdb-feature-preset-env-badge-link {
+	margin-inline-start: 10px;
 }
 
 /* Examples
@@ -408,6 +392,7 @@ img {
 .cssdb-feature-caniuse {
 	display: inline-flex;
 	flex-wrap: wrap;
+	margin-block-start: 15px;
 }
 
 .cssdb-browser {

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -198,7 +198,7 @@ img {
 
 .cssdb-feature-header {
 	display: grid;
-	gap: 5px 20px;
+	gap: 5px 15px;
 	grid:
 		"stage title"
 		"stage description"
@@ -232,6 +232,7 @@ img {
 
 .cssdb-feature-docs {
 	font-size: 87.5%;
+	margin-block-start: 20px;
 }
 
 .cssdb-feature-docs-link {
@@ -290,13 +291,11 @@ img {
 	}
 
 	& .cssdb-feature-polyfill-stars-minimal {
-		margin-inline-start: 3px;
 		overflow: hidden;
-		inline-size: 32px;
 
 		& img {
 			height: 20px;
-			transform: translateX(-58px);
+			margin-inline-start: -56px;
 		}
 	}
 }
@@ -392,7 +391,7 @@ img {
 .cssdb-feature-caniuse {
 	display: inline-flex;
 	flex-wrap: wrap;
-	margin-block-start: 15px;
+	margin-block-start: 5px;
 }
 
 .cssdb-browser {

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -296,6 +296,7 @@ img {
 		& img {
 			height: 20px;
 			margin-inline-start: -56px;
+			min-width: 57px;
 		}
 	}
 }


### PR DESCRIPTION
Hello. Thank you for putting together this site. It's such a useful destination to learn about the new stuff in CSS!

When I was looking through it I found the links and badges below the description of each feature a bit disjointed. I think because:

- the combination of internal and external links
- the combination of badges and text links
- the preset badge is related to the polyfill listed at the bottom of the feature 

This pull request loses the badges and splits each feature into two sections:

- About
  - Stage
  - Title
  - Description
  - Example 
  - Spec and Doc links (if the above info isn't enough and a person wants to learn more)
- Support
  - Browsers
  - Polyfills and plugins (and whether the PostCSS plugin is included in Preset Env).

It also removes the redundancy of the staging badge in favour of adding an anchor link to the stage image.

Goes from this:

<img width="705" alt="Screenshot 2022-01-31 at 17 42 40" src="https://user-images.githubusercontent.com/808227/152008838-69a46fc5-236d-456c-9d37-85eedb587b33.png">

To this:

<img width="793" alt="Screenshot 2022-02-01 at 16 01 12" src="https://user-images.githubusercontent.com/808227/152008894-c0048464-92c5-484a-b6fe-a438f8207a21.png">

It's not quite as compact, but the grouping of related information feels better. What do you think? 

Behind the scenes, this pull request moves the code related to the present env into the polyfills components.



