### PR TITLE
Add opacity percentage polyfill

### DIFF
--- a/cssdb.json
+++ b/cssdb.json
@@ -1067,6 +1067,12 @@
       "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/opacity"
     },
     "example": "img {\n  opacity: 90%;\n}",
+    "polyfills": [
+      {
+        "type": "PostCSS Plugin",
+        "link": "https://github.com/mrcgrtz/postcss-opacity-percentage"
+      }
+    ],
     "vendors_implementations": 2
   },
   {

--- a/cssdb.mjs
+++ b/cssdb.mjs
@@ -1067,6 +1067,12 @@ export default [
       "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/opacity"
     },
     "example": "img {\n  opacity: 90%;\n}",
+    "polyfills": [
+      {
+        "type": "PostCSS Plugin",
+        "link": "https://github.com/mrcgrtz/postcss-opacity-percentage"
+      }
+    ],
     "vendors_implementations": 2
   },
   {

--- a/cssdb.settings.json
+++ b/cssdb.settings.json
@@ -776,7 +776,13 @@
       "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/opacity"
     },
     "example": "img {\n  opacity: 90%;\n}",
-    "mdn_path": "css.properties.opacity.percentages"
+    "mdn_path": "css.properties.opacity.percentages",
+    "polyfills": [
+      {
+        "type": "PostCSS Plugin",
+        "link": "https://github.com/mrcgrtz/postcss-opacity-percentage"
+      }
+    ]
   },
   {
     "id": "overflow-property",

--- a/src/components/feature-polyfill.astro
+++ b/src/components/feature-polyfill.astro
@@ -31,6 +31,7 @@ const presetEnvPlugins = [
 	'media-query-ranges',
 	'nesting-rules',
 	'not-pseudo-class',
+	'opacity-percentage',
 	'overflow-property',
 	'overflow-wrap-property',
 	'place-properties',
@@ -57,5 +58,5 @@ const isBundled = presetEnvPlugins.includes(id);
 	)}
 	{(polyfill.type === "PostCSS Plugin" && isBundled) &&  (
 		<span> (bundled with <a class="cssdb-feature-polyfill-link" href="https://github.com/csstools/postcss-plugins/blob/main/plugin-packs/postcss-preset-env">Preset Env</a>)</span>
-	)}	
+	)}
 </li>


### PR DESCRIPTION
* Add [`postcss-opacity-percentage`](https://github.com/mrcgrtz/postcss-opacity-percentage) as a polyfill to [cssdb.org/#opacity-percentage](https://cssdb.org/#opacity-percentage)
* Add `postcss-opacity-percentage` to the list of included plugins in `postcss-preset-env` as of [v7.3.0](https://github.com/csstools/postcss-plugins/blob/main/plugin-packs/postcss-preset-env/CHANGELOG.md#730-january-31-2022)