### PR TITLE
Update contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,15 +12,15 @@ further clarification, read [why we are doing this](#why-are-we-doing-this).
 
 ### Updating a feature
 
-Is one of these CSS features out-of-date? Open [`cssdb.json`] and find the
-feature you want to update. It’s a JSON file, so make changes directly to the
-file, commit it, and then [make a pull request](#making-a-pull-request).
+Is one of these CSS features out-of-date? Open [`cssdb.settings.json`] and find
+the feature you want to update. It’s a JSON file, so make changes directly to
+the file, commit it, and then [make a pull request](#making-a-pull-request).
 
 ### Adding a new feature
 
-Is a CSS feature not listed here? Add the feature to [`cssdb.json`]. Again,
-it’s a JSON file, so make changes directly to the JSON, commit it, and then
-[make a pull request](#making-a-pull-request).
+Is a CSS feature not listed here? Add the feature to [`cssdb.settings.json`].
+Again, it’s a JSON file, so make changes directly to the JSON, commit it, and
+then [make a pull request](#making-a-pull-request).
 
 ### Making a Pull Request
 
@@ -70,7 +70,7 @@ you’re unfamiliar with git, consider the following workflow.
 
 ## Advanced Usage: How the JSON file looks
 
-The only fields you’ll see in [`cssdb.json`] are, in order:
+The only fields you’ll see in [`cssdb.settings.json`] are, in order:
 
 - `id`: the feature shortname, similar to a specification [Shortname].
 - `title`: the name of the feature.
@@ -91,7 +91,7 @@ The only fields you’ll see in [`cssdb.json`] are, in order:
 All contributions must follow the existing syntax and style of the JSON file,
 which;
 
-1. Exists as `cssdb.json`, and;
+1. Exists as `cssdb.settings.json`, and;
 2. Includes at least the required fields; **title**, **description**,
    **specification**, and **stage** (which is `0` if you don’t know it).
 
@@ -122,7 +122,7 @@ browsers
 so we have to discern what’s really going on ourselves. If we didn’t, we
 probably wouldn’t need this repository.
 
-[`cssdb.json`]: cssdb.json
+[`cssdb.settings.json`]: cssdb.settings.json
 [fork this project]: fork
 [instructions for joining the CSSWG]: https://www.w3.org/2004/01/pp-impl/32061/instructions
 [staging process]: README.md#staging-process


### PR DESCRIPTION
Update `CONTRIBUTING.md` as apparently `cssdb.settings.json` is the single source of truth. Otherwise when hitting `npm start` (or the `build` task) any changes to `cssdb.json` will be reverted.