### PR TITLE
New CSS features

### DIFF
--- a/cssdb.json
+++ b/cssdb.json
@@ -129,9 +129,11 @@
       "firefox": "97",
       "chrome": "99",
       "safari": "15.4",
+      "opera": "86",
       "ios_saf": "15.4",
       "android": "99",
-      "and_chr": "99"
+      "and_chr": "99",
+      "and_ff": "97"
     },
     "docs": {
       "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/@layer"
@@ -824,7 +826,7 @@
         "link": "https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-hwb-function"
       }
     ],
-    "vendors_implementations": 2
+    "vendors_implementations": 3
   },
   {
     "id": "ic-unit",

--- a/cssdb.json
+++ b/cssdb.json
@@ -522,6 +522,22 @@
     "vendors_implementations": 3
   },
   {
+    "id": "exponential-functions",
+    "title": "`pow()`, `sqrt()`, `hypot()`, `log()`, `exp()` exponential functions",
+    "description": "Compute various exponential functions with their arguments",
+    "specification": "https://www.w3.org/TR/css-values-4/#exponent-funcs",
+    "stage": 2,
+    "browser_support": {},
+    "example": "p {\n  font-size: calc(pow(10, 12) * 1rem);\n  font-size: calc(sqrt(100) * 1rem);\n  font-size: calc(hypot(3, 4) * 1rem);\n  font-size: calc(log(10) * 1rem);\n  font-size: calc(exp(10) * 1rem);\n}",
+    "polyfills": [
+      {
+        "type": "PostCSS Plugin",
+        "link": "https://github.com/JLHwung/postcss-font-family-fangsong"
+      }
+    ],
+    "vendors_implementations": 0
+  },
+  {
     "id": "fangsong-font-family",
     "title": "`fangsong` Font Family",
     "description": "A generic font used for Fang Song (仿宋) typefaces in Chinese",
@@ -1389,6 +1405,16 @@
     "vendors_implementations": 3
   },
   {
+    "id": "stepped-value-functions",
+    "title": "`round()`, `mod()` and `rem()` functions",
+    "description": "The stepped-value functions, `round()`, `mod()`, and `rem()`, all transform a given value according to another \"step value\", in different ways.",
+    "specification": "https://www.w3.org/TR/css-values-4/#round-func",
+    "stage": 2,
+    "browser_support": {},
+    "example": "div {\n  left: mod(18px, 5px);\n  top: rem(18px, 5px);\n  right: round(2.5px, 1px);\n  bottom: round(up, 15px, 7px);\n}",
+    "vendors_implementations": 0
+  },
+  {
     "id": "system-ui-font-family",
     "title": "`system-ui` Font Family",
     "description": "A generic font used to match the user’s interface",
@@ -1420,6 +1446,19 @@
       }
     ],
     "vendors_implementations": 3
+  },
+  {
+    "id": "trigonometric-functions",
+    "title": "`sin()`, `cos()`, `tan()`, `asin()`, `acos()`, `atan()` and `atan2()` functions",
+    "description": "Functions to calculate varios basic trigonometric relationships",
+    "specification": "https://www.w3.org/TR/css-values-4/#trig-funcs",
+    "stage": 2,
+    "browser_support": {
+      "safari": "15.4",
+      "ios_saf": "15.4"
+    },
+    "example": "body {\n  left: sin(45deg);\n  left: cos(45deg);\n  left: tan(45deg);\n  left: asin(0.5);\n  left: acos(0.5);\n  left: atan(10);\n  left: atan2(-1, 1);\n}",
+    "vendors_implementations": 1
   },
   {
     "id": "unset-value",

--- a/cssdb.mjs
+++ b/cssdb.mjs
@@ -522,6 +522,22 @@ export default [
     "vendors_implementations": 3
   },
   {
+    "id": "exponential-functions",
+    "title": "`pow()`, `sqrt()`, `hypot()`, `log()`, `exp()` exponential functions",
+    "description": "Compute various exponential functions with their arguments",
+    "specification": "https://www.w3.org/TR/css-values-4/#exponent-funcs",
+    "stage": 2,
+    "browser_support": {},
+    "example": "p {\n  font-size: calc(pow(10, 12) * 1rem);\n  font-size: calc(sqrt(100) * 1rem);\n  font-size: calc(hypot(3, 4) * 1rem);\n  font-size: calc(log(10) * 1rem);\n  font-size: calc(exp(10) * 1rem);\n}",
+    "polyfills": [
+      {
+        "type": "PostCSS Plugin",
+        "link": "https://github.com/JLHwung/postcss-font-family-fangsong"
+      }
+    ],
+    "vendors_implementations": 0
+  },
+  {
     "id": "fangsong-font-family",
     "title": "`fangsong` Font Family",
     "description": "A generic font used for Fang Song (仿宋) typefaces in Chinese",
@@ -1389,6 +1405,16 @@ export default [
     "vendors_implementations": 3
   },
   {
+    "id": "stepped-value-functions",
+    "title": "`round()`, `mod()` and `rem()` functions",
+    "description": "The stepped-value functions, `round()`, `mod()`, and `rem()`, all transform a given value according to another \"step value\", in different ways.",
+    "specification": "https://www.w3.org/TR/css-values-4/#round-func",
+    "stage": 2,
+    "browser_support": {},
+    "example": "div {\n  left: mod(18px, 5px);\n  top: rem(18px, 5px);\n  right: round(2.5px, 1px);\n  bottom: round(up, 15px, 7px);\n}",
+    "vendors_implementations": 0
+  },
+  {
     "id": "system-ui-font-family",
     "title": "`system-ui` Font Family",
     "description": "A generic font used to match the user’s interface",
@@ -1420,6 +1446,19 @@ export default [
       }
     ],
     "vendors_implementations": 3
+  },
+  {
+    "id": "trigonometric-functions",
+    "title": "`sin()`, `cos()`, `tan()`, `asin()`, `acos()`, `atan()` and `atan2()` functions",
+    "description": "Functions to calculate varios basic trigonometric relationships",
+    "specification": "https://www.w3.org/TR/css-values-4/#trig-funcs",
+    "stage": 2,
+    "browser_support": {
+      "safari": "15.4",
+      "ios_saf": "15.4"
+    },
+    "example": "body {\n  left: sin(45deg);\n  left: cos(45deg);\n  left: tan(45deg);\n  left: asin(0.5);\n  left: acos(0.5);\n  left: atan(10);\n  left: atan2(-1, 1);\n}",
+    "vendors_implementations": 1
   },
   {
     "id": "unset-value",

--- a/cssdb.mjs
+++ b/cssdb.mjs
@@ -129,9 +129,11 @@ export default [
       "firefox": "97",
       "chrome": "99",
       "safari": "15.4",
+      "opera": "86",
       "ios_saf": "15.4",
       "android": "99",
-      "and_chr": "99"
+      "and_chr": "99",
+      "and_ff": "97"
     },
     "docs": {
       "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/@layer"
@@ -824,7 +826,7 @@ export default [
         "link": "https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-hwb-function"
       }
     ],
-    "vendors_implementations": 2
+    "vendors_implementations": 3
   },
   {
     "id": "ic-unit",

--- a/cssdb.settings.json
+++ b/cssdb.settings.json
@@ -391,6 +391,15 @@
     ]
   },
   {
+    "id": "exponential-functions",
+    "title": "`pow()`, `sqrt()`, `hypot()`, `log()`, `exp()` exponential functions",
+    "description": "Compute various exponential functions with their arguments",
+    "specification": "https://www.w3.org/TR/css-values-4/#exponent-funcs",
+    "stage": 2,
+    "browser_support": {},
+    "example": "p {\n  font-size: calc(pow(10, 12) * 1rem);\n  font-size: calc(sqrt(100) * 1rem);\n  font-size: calc(hypot(3, 4) * 1rem);\n  font-size: calc(log(10) * 1rem);\n  font-size: calc(exp(10) * 1rem);\n}"
+  },
+  {
     "id": "fangsong-font-family",
     "title": "`fangsong` Font Family",
     "description": "A generic font used for Fang Song (仿宋) typefaces in Chinese",
@@ -810,6 +819,15 @@
     ]
   },
   {
+    "id": "calc-constants",
+    "title": "`e`, `pi`, `infinity`, `-infinity and `NaN` constants for calculation",
+    "description": "Constants for calculation simplification",
+    "specification": "https://www.w3.org/TR/css-values-4/#calc-constants",
+    "stage": 2,
+    "browser_support": {},
+    "example": "p {\n  font-size: calc(calc(pow(e, pi) - pi) * 1rem);\n}"
+  },
+  {
     "id": "oklab-function",
     "title": "`oklab` and `oklch` color functions",
     "description": "Functions that allow colors to be expressed in OKLab and OKLCH.",
@@ -986,6 +1004,24 @@
     ]
   },
   {
+    "id": "sign-functions",
+    "title": "`abs()` and `sign()` functions",
+    "description": "he sign-related functions—abs() and sign()—compute various functions related to the sign of their argument",
+    "specification": "https://www.w3.org/TR/css-values-4/#sign-funcs",
+    "stage": 2,
+    "browser_support": {},
+    "example": "div {\n  order: abs(-10);\n  order: sign(-10);\n}"
+  },
+  {
+    "id": "stepped-value-functions",
+    "title": "`round()`, `mod()` and `rem()` functions",
+    "description": "The stepped-value functions, `round()`, `mod()`, and `rem()`, all transform a given value according to another \"step value\", in different ways",
+    "specification": "https://www.w3.org/TR/css-values-4/#round-func",
+    "stage": 2,
+    "browser_support": {},
+    "example": "div {\n  left: mod(18px, 5px);\n  top: rem(18px, 5px);\n  right: round(2.5px, 1px);\n  bottom: round(up, 15px, 7px);\n}"
+  },
+  {
     "id": "system-ui-font-family",
     "title": "`system-ui` Font Family",
     "description": "A generic font used to match the user’s interface",
@@ -1003,6 +1039,18 @@
         "link": "https://github.com/JLHwung/postcss-font-family-system-ui"
       }
     ]
+  },
+  {
+    "id": "trigonometric-functions",
+    "title": "`sin()`, `cos()`, `tan()`, `asin()`, `acos()`, `atan()` and `atan2()` functions",
+    "description": "Functions to calculate varios basic trigonometric relationships",
+    "specification": "https://www.w3.org/TR/css-values-4/#trig-funcs",
+    "stage": 2,
+    "browser_support": {
+      "safari": "15.4",
+      "ios_saf": "15.4"
+    },
+    "example": "body {\n  left: sin(45deg);\n  left: cos(45deg);\n  left: tan(45deg);\n  left: asin(0.5);\n  left: acos(0.5);\n  left: atan(10);\n  left: atan2(-1, 1);\n}"
   },
   {
     "id": "unset-value",

--- a/cssdb.settings.json
+++ b/cssdb.settings.json
@@ -1006,7 +1006,7 @@
   {
     "id": "sign-functions",
     "title": "`abs()` and `sign()` functions",
-    "description": "he sign-related functions—abs() and sign()—compute various functions related to the sign of their argument",
+    "description": "The sign-related functions—abs() and sign()—compute various functions related to the sign of their argument",
     "specification": "https://www.w3.org/TR/css-values-4/#sign-funcs",
     "stage": 2,
     "browser_support": {},

--- a/cssdb.settings.json
+++ b/cssdb.settings.json
@@ -825,7 +825,7 @@
     "specification": "https://www.w3.org/TR/css-values-4/#calc-constants",
     "stage": 2,
     "browser_support": {},
-    "example": "p {\n  font-size: calc(calc(pow(e, pi) - pi) * 1rem);\n}"
+    "example": "p {\n  font-size: calc(pow(e, pi) * 1rem);\n}"
   },
   {
     "id": "oklab-function",

--- a/cssdb.settings.json
+++ b/cssdb.settings.json
@@ -820,7 +820,7 @@
   },
   {
     "id": "calc-constants",
-    "title": "`e`, `pi`, `infinity`, `-infinity and `NaN` constants for calculation",
+    "title": "`e`, `pi`, `infinity`, `-infinity` and `NaN` constants for calculation",
     "description": "Constants for calculation simplification",
     "specification": "https://www.w3.org/TR/css-values-4/#calc-constants",
     "stage": 2,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,16 +10,16 @@
       "license": "CC0-1.0",
       "devDependencies": {
         "@astropub/webapi": "^0.10.14",
-        "@mdn/browser-compat-data": "^4.1.17",
+        "@mdn/browser-compat-data": "^4.1.18",
         "astro": "0.24.3",
         "browserslist": "^4.20.3",
-        "caniuse-lite": "^1.0.30001332",
+        "caniuse-lite": "^1.0.30001334",
         "fse": "^4.0.1",
         "lodash.get": "^4.4.2",
-        "postcss": "^8.4.12",
-        "postcss-preset-env": "^7.4.3",
+        "postcss": "^8.4.13",
+        "postcss-preset-env": "^7.4.4",
         "pre-commit": "^1.2.2",
-        "stylelint": "^14.7.1",
+        "stylelint": "^14.8.1",
         "stylelint-config-standard": "^25.0.0"
       },
       "funding": {
@@ -554,9 +554,9 @@
       }
     },
     "node_modules/@csstools/postcss-color-function": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-color-function/-/postcss-color-function-1.0.3.tgz",
-      "integrity": "sha512-J26I69pT2B3MYiLY/uzCGKVJyMYVg9TCpXkWsRlt+Yfq+nELUEm72QXIMYXs4xA9cJA4Oqs2EylrfokKl3mJEQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-color-function/-/postcss-color-function-1.1.0.tgz",
+      "integrity": "sha512-5D5ND/mZWcQoSfYnSPsXtuiFxhzmhxt6pcjrFLJyldj+p0ZN2vvRpYNX+lahFTtMhAYOa2WmkdGINr0yP0CvGA==",
       "dev": true,
       "dependencies": {
         "@csstools/postcss-progressive-custom-properties": "^1.1.0",
@@ -564,6 +564,10 @@
       },
       "engines": {
         "node": "^12 || ^14 || >=16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/csstools"
       },
       "peerDependencies": {
         "postcss": "^8.4"
@@ -616,15 +620,19 @@
       }
     },
     "node_modules/@csstools/postcss-is-pseudo-class": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-is-pseudo-class/-/postcss-is-pseudo-class-2.0.1.tgz",
-      "integrity": "sha512-Og5RrTzwFhrKoA79c3MLkfrIBYmwuf/X83s+JQtz/Dkk/MpsaKtqHV1OOzYkogQ+tj3oYp5Mq39XotBXNqVc3Q==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-is-pseudo-class/-/postcss-is-pseudo-class-2.0.2.tgz",
+      "integrity": "sha512-L9h1yxXMj7KpgNzlMrw3isvHJYkikZgZE4ASwssTnGEH8tm50L6QsM9QQT5wR4/eO5mU0rN5axH7UzNxEYg5CA==",
       "dev": true,
       "dependencies": {
-        "postcss-selector-parser": "^6.0.9"
+        "postcss-selector-parser": "^6.0.10"
       },
       "engines": {
         "node": "^12 || ^14 || >=16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/csstools"
       },
       "peerDependencies": {
         "postcss": "^8.4"
@@ -646,9 +654,9 @@
       }
     },
     "node_modules/@csstools/postcss-oklab-function": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-oklab-function/-/postcss-oklab-function-1.0.2.tgz",
-      "integrity": "sha512-QwhWesEkMlp4narAwUi6pgc6kcooh8cC7zfxa9LSQNYXqzcdNUtNBzbGc5nuyAVreb7uf5Ox4qH1vYT3GA1wOg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-oklab-function/-/postcss-oklab-function-1.1.0.tgz",
+      "integrity": "sha512-e/Q5HopQzmnQgqimG9v3w2IG4VRABsBq3itOcn4bnm+j4enTgQZ0nWsaH/m9GV2otWGQ0nwccYL5vmLKyvP1ww==",
       "dev": true,
       "dependencies": {
         "@csstools/postcss-progressive-custom-properties": "^1.1.0",
@@ -656,6 +664,10 @@
       },
       "engines": {
         "node": "^12 || ^14 || >=16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/csstools"
       },
       "peerDependencies": {
         "postcss": "^8.4"
@@ -732,9 +744,9 @@
       "dev": true
     },
     "node_modules/@mdn/browser-compat-data": {
-      "version": "4.1.17",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-4.1.17.tgz",
-      "integrity": "sha512-o7hCdjCR5S1beYsOlfwqeXMujqlryV8/nJlM7xmv8HIAb4E4SN/YOE4cwmvZErUkgiVZkApvUDePDnIcxthmAQ==",
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-4.1.18.tgz",
+      "integrity": "sha512-Ap8MOYbyvEilK1+sNY6yh6LmsHSp7f5zzSGlY4AemhbTcoultcozEXPzx42OO6WjoriOsw88aW8TiqgYdXwsxg==",
       "dev": true
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1356,9 +1368,9 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.4",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.4.tgz",
-      "integrity": "sha512-Tm8JxsB286VweiZ5F0anmbyGiNI3v3wGv3mz9W+cxEDYB/6jbnj6GM9H9mK3wIL8ftgl+C07Lcwb8PG5PCCPzA==",
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.5.tgz",
+      "integrity": "sha512-Fvd8yCoA7lNX/OUllvS+aS1I7WRBclGXsepbvT8ZaPgrH24rgXpZzF0/6Hh3ZEkwg+0AES/Osd196VZmYoEFtw==",
       "dev": true,
       "funding": [
         {
@@ -1372,7 +1384,7 @@
       ],
       "dependencies": {
         "browserslist": "^4.20.2",
-        "caniuse-lite": "^1.0.30001317",
+        "caniuse-lite": "^1.0.30001332",
         "fraction.js": "^4.2.0",
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
@@ -1531,9 +1543,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001332",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001332.tgz",
-      "integrity": "sha512-10T30NYOEQtN6C11YGg411yebhvpnC6Z102+B95eAsN0oB6KUs01ivE8u+G6FMIRtIrVlYXhL+LUwQ3/hXwDWw==",
+      "version": "1.0.30001334",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001334.tgz",
+      "integrity": "sha512-kbaCEBRRVSoeNs74sCuq92MJyGrMtjWVfhltoHUCW4t4pXFvGjUBrfo47weBRViHkiV3eBYyIsfl956NtHGazw==",
       "dev": true,
       "funding": [
         {
@@ -5068,9 +5080,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
-      "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
+      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
       "dev": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
@@ -5384,9 +5396,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.12.tgz",
-      "integrity": "sha512-lg6eITwYe9v6Hr5CncVbK70SoioNQIq81nsaG86ev5hAidQvmOeETBqs7jm43K2F5/Ley3ytDtriImV6TpNiSg==",
+      "version": "8.4.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.13.tgz",
+      "integrity": "sha512-jtL6eTBrza5MPzy8oJLFuUscHDXTV5KcLlqAWHl5q5WYRfnNRGSmOZmOZ1T6Gy7A99mOZfqungmZMpMmCVJ8ZA==",
       "dev": true,
       "funding": [
         {
@@ -5399,7 +5411,7 @@
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.1",
+        "nanoid": "^3.3.3",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       },
@@ -5492,15 +5504,19 @@
       }
     },
     "node_modules/postcss-custom-properties": {
-      "version": "12.1.5",
-      "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-12.1.5.tgz",
-      "integrity": "sha512-FHbbB/hRo/7cxLGkc2NS7cDRIDN1oFqQnUKBiyh4b/gwk8DD8udvmRDpUhEK836kB8ggUCieHVOvZDnF9XhI3g==",
+      "version": "12.1.7",
+      "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-12.1.7.tgz",
+      "integrity": "sha512-N/hYP5gSoFhaqxi2DPCmvto/ZcRDVjE3T1LiAMzc/bg53hvhcHOLpXOHb526LzBBp5ZlAUhkuot/bfpmpgStJg==",
       "dev": true,
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
         "node": "^12 || ^14 || >=16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/csstools"
       },
       "peerDependencies": {
         "postcss": "^8.4"
@@ -5643,9 +5659,9 @@
       }
     },
     "node_modules/postcss-lab-function": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-lab-function/-/postcss-lab-function-4.1.2.tgz",
-      "integrity": "sha512-isudf5ldhg4fk16M8viAwAbg6Gv14lVO35N3Z/49NhbwPQ2xbiEoHgrRgpgQojosF4vF7jY653ktB6dDrUOR8Q==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-lab-function/-/postcss-lab-function-4.2.0.tgz",
+      "integrity": "sha512-Zb1EO9DGYfa3CP8LhINHCcTTCTLI+R3t7AX2mKsDzdgVQ/GkCpHOTgOr6HBHslP7XDdVbqgHW5vvRPMdVANQ8w==",
       "dev": true,
       "dependencies": {
         "@csstools/postcss-progressive-custom-properties": "^1.1.0",
@@ -5653,6 +5669,10 @@
       },
       "engines": {
         "node": "^12 || ^14 || >=16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/csstools"
       },
       "peerDependencies": {
         "postcss": "^8.4"
@@ -5689,15 +5709,19 @@
       "dev": true
     },
     "node_modules/postcss-nesting": {
-      "version": "10.1.3",
-      "resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-10.1.3.tgz",
-      "integrity": "sha512-wUC+/YCik4wH3StsbC5fBG1s2Z3ZV74vjGqBFYtmYKlVxoio5TYGM06AiaKkQPPlkXWn72HKfS7Cw5PYxnoXSw==",
+      "version": "10.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-10.1.4.tgz",
+      "integrity": "sha512-2ixdQ59ik/Gt1+oPHiI1kHdwEI8lLKEmui9B1nl6163ANLC+GewQn7fXMxJF2JSb4i2MKL96GU8fIiQztK4TTA==",
       "dev": true,
       "dependencies": {
-        "postcss-selector-parser": "^6.0.9"
+        "postcss-selector-parser": "^6.0.10"
       },
       "engines": {
         "node": "^12 || ^14 || >=16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/csstools"
       },
       "peerDependencies": {
         "postcss": "^8.4"
@@ -5759,21 +5783,21 @@
       }
     },
     "node_modules/postcss-preset-env": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-7.4.3.tgz",
-      "integrity": "sha512-dlPA65g9KuGv7YsmGyCKtFkZKCPLkoVMUE3omOl6yM+qrynVHxFvf0tMuippIrXB/sB/MyhL1FgTIbrO+qMERg==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-7.4.4.tgz",
+      "integrity": "sha512-MqzSEx/QsvOk562iV9mLTgIvLFEOq1os9QBQfkgnq8TW6yKhVFPGh0gdXSK5ZlmjuNQEga6/x833e86XZF/lug==",
       "dev": true,
       "dependencies": {
-        "@csstools/postcss-color-function": "^1.0.3",
+        "@csstools/postcss-color-function": "^1.1.0",
         "@csstools/postcss-font-format-keywords": "^1.0.0",
         "@csstools/postcss-hwb-function": "^1.0.0",
         "@csstools/postcss-ic-unit": "^1.0.0",
-        "@csstools/postcss-is-pseudo-class": "^2.0.1",
+        "@csstools/postcss-is-pseudo-class": "^2.0.2",
         "@csstools/postcss-normalize-display-values": "^1.0.0",
-        "@csstools/postcss-oklab-function": "^1.0.2",
+        "@csstools/postcss-oklab-function": "^1.1.0",
         "@csstools/postcss-progressive-custom-properties": "^1.3.0",
-        "autoprefixer": "^10.4.4",
-        "browserslist": "^4.20.2",
+        "autoprefixer": "^10.4.5",
+        "browserslist": "^4.20.3",
         "css-blank-pseudo": "^3.0.3",
         "css-has-pseudo": "^3.0.4",
         "css-prefers-color-scheme": "^6.0.3",
@@ -5784,7 +5808,7 @@
         "postcss-color-hex-alpha": "^8.0.3",
         "postcss-color-rebeccapurple": "^7.0.2",
         "postcss-custom-media": "^8.0.0",
-        "postcss-custom-properties": "^12.1.5",
+        "postcss-custom-properties": "^12.1.7",
         "postcss-custom-selectors": "^6.0.0",
         "postcss-dir-pseudo-class": "^6.0.4",
         "postcss-double-position-gradients": "^3.1.1",
@@ -5795,15 +5819,15 @@
         "postcss-gap-properties": "^3.0.3",
         "postcss-image-set-function": "^4.0.6",
         "postcss-initial": "^4.0.1",
-        "postcss-lab-function": "^4.1.2",
+        "postcss-lab-function": "^4.2.0",
         "postcss-logical": "^5.0.4",
         "postcss-media-minmax": "^5.0.0",
-        "postcss-nesting": "^10.1.3",
+        "postcss-nesting": "^10.1.4",
         "postcss-opacity-percentage": "^1.1.2",
         "postcss-overflow-shorthand": "^3.0.3",
         "postcss-page-break": "^3.0.4",
         "postcss-place": "^7.0.4",
-        "postcss-pseudo-class-any-link": "^7.1.1",
+        "postcss-pseudo-class-any-link": "^7.1.2",
         "postcss-replace-overflow-wrap": "^4.0.0",
         "postcss-selector-not": "^5.0.0",
         "postcss-value-parser": "^4.2.0"
@@ -5811,20 +5835,28 @@
       "engines": {
         "node": "^12 || ^14 || >=16"
       },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/csstools"
+      },
       "peerDependencies": {
         "postcss": "^8.4"
       }
     },
     "node_modules/postcss-pseudo-class-any-link": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-7.1.1.tgz",
-      "integrity": "sha512-JRoLFvPEX/1YTPxRxp1JO4WxBVXJYrSY7NHeak5LImwJ+VobFMwYDQHvfTXEpcn+7fYIeGkC29zYFhFWIZD8fg==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-7.1.2.tgz",
+      "integrity": "sha512-76XzEQv3g+Vgnz3tmqh3pqQyRojkcJ+pjaePsyhcyf164p9aZsu3t+NWxkZYbcHLK1ju5Qmalti2jPI5IWCe5w==",
       "dev": true,
       "dependencies": {
-        "postcss-selector-parser": "^6.0.9"
+        "postcss-selector-parser": "^6.0.10"
       },
       "engines": {
         "node": "^12 || ^14 || >=16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/csstools"
       },
       "peerDependencies": {
         "postcss": "^8.4"
@@ -6929,9 +6961,9 @@
       }
     },
     "node_modules/stylelint": {
-      "version": "14.7.1",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.7.1.tgz",
-      "integrity": "sha512-rUOWm67hrzGXXyO/cInENEejF4urh1dLgOb9cr/3XLDb/t/A+rXQp3p6+no8o8QCKTgBUdhVUq/bXMgE988PJw==",
+      "version": "14.8.1",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.8.1.tgz",
+      "integrity": "sha512-0YxTop3wTeEVmQWhS7jjLFaBkvfPmffRiJ6eFIDlK++f3OklaobTYFJu32E5u/cIrFLbcW52pLqrYpihA/y0/w==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^2.0.0",
@@ -8436,9 +8468,9 @@
       }
     },
     "@csstools/postcss-color-function": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-color-function/-/postcss-color-function-1.0.3.tgz",
-      "integrity": "sha512-J26I69pT2B3MYiLY/uzCGKVJyMYVg9TCpXkWsRlt+Yfq+nELUEm72QXIMYXs4xA9cJA4Oqs2EylrfokKl3mJEQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-color-function/-/postcss-color-function-1.1.0.tgz",
+      "integrity": "sha512-5D5ND/mZWcQoSfYnSPsXtuiFxhzmhxt6pcjrFLJyldj+p0ZN2vvRpYNX+lahFTtMhAYOa2WmkdGINr0yP0CvGA==",
       "dev": true,
       "requires": {
         "@csstools/postcss-progressive-custom-properties": "^1.1.0",
@@ -8474,12 +8506,12 @@
       }
     },
     "@csstools/postcss-is-pseudo-class": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-is-pseudo-class/-/postcss-is-pseudo-class-2.0.1.tgz",
-      "integrity": "sha512-Og5RrTzwFhrKoA79c3MLkfrIBYmwuf/X83s+JQtz/Dkk/MpsaKtqHV1OOzYkogQ+tj3oYp5Mq39XotBXNqVc3Q==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-is-pseudo-class/-/postcss-is-pseudo-class-2.0.2.tgz",
+      "integrity": "sha512-L9h1yxXMj7KpgNzlMrw3isvHJYkikZgZE4ASwssTnGEH8tm50L6QsM9QQT5wR4/eO5mU0rN5axH7UzNxEYg5CA==",
       "dev": true,
       "requires": {
-        "postcss-selector-parser": "^6.0.9"
+        "postcss-selector-parser": "^6.0.10"
       }
     },
     "@csstools/postcss-normalize-display-values": {
@@ -8492,9 +8524,9 @@
       }
     },
     "@csstools/postcss-oklab-function": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-oklab-function/-/postcss-oklab-function-1.0.2.tgz",
-      "integrity": "sha512-QwhWesEkMlp4narAwUi6pgc6kcooh8cC7zfxa9LSQNYXqzcdNUtNBzbGc5nuyAVreb7uf5Ox4qH1vYT3GA1wOg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-oklab-function/-/postcss-oklab-function-1.1.0.tgz",
+      "integrity": "sha512-e/Q5HopQzmnQgqimG9v3w2IG4VRABsBq3itOcn4bnm+j4enTgQZ0nWsaH/m9GV2otWGQ0nwccYL5vmLKyvP1ww==",
       "dev": true,
       "requires": {
         "@csstools/postcss-progressive-custom-properties": "^1.1.0",
@@ -8563,9 +8595,9 @@
       "dev": true
     },
     "@mdn/browser-compat-data": {
-      "version": "4.1.17",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-4.1.17.tgz",
-      "integrity": "sha512-o7hCdjCR5S1beYsOlfwqeXMujqlryV8/nJlM7xmv8HIAb4E4SN/YOE4cwmvZErUkgiVZkApvUDePDnIcxthmAQ==",
+      "version": "4.1.18",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-4.1.18.tgz",
+      "integrity": "sha512-Ap8MOYbyvEilK1+sNY6yh6LmsHSp7f5zzSGlY4AemhbTcoultcozEXPzx42OO6WjoriOsw88aW8TiqgYdXwsxg==",
       "dev": true
     },
     "@nodelib/fs.scandir": {
@@ -9111,13 +9143,13 @@
       }
     },
     "autoprefixer": {
-      "version": "10.4.4",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.4.tgz",
-      "integrity": "sha512-Tm8JxsB286VweiZ5F0anmbyGiNI3v3wGv3mz9W+cxEDYB/6jbnj6GM9H9mK3wIL8ftgl+C07Lcwb8PG5PCCPzA==",
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.5.tgz",
+      "integrity": "sha512-Fvd8yCoA7lNX/OUllvS+aS1I7WRBclGXsepbvT8ZaPgrH24rgXpZzF0/6Hh3ZEkwg+0AES/Osd196VZmYoEFtw==",
       "dev": true,
       "requires": {
         "browserslist": "^4.20.2",
-        "caniuse-lite": "^1.0.30001317",
+        "caniuse-lite": "^1.0.30001332",
         "fraction.js": "^4.2.0",
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
@@ -9220,9 +9252,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001332",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001332.tgz",
-      "integrity": "sha512-10T30NYOEQtN6C11YGg411yebhvpnC6Z102+B95eAsN0oB6KUs01ivE8u+G6FMIRtIrVlYXhL+LUwQ3/hXwDWw==",
+      "version": "1.0.30001334",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001334.tgz",
+      "integrity": "sha512-kbaCEBRRVSoeNs74sCuq92MJyGrMtjWVfhltoHUCW4t4pXFvGjUBrfo47weBRViHkiV3eBYyIsfl956NtHGazw==",
       "dev": true
     },
     "ccount": {
@@ -11625,9 +11657,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
-      "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
+      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
       "dev": true
     },
     "nlcst-to-string": {
@@ -11854,12 +11886,12 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.4.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.12.tgz",
-      "integrity": "sha512-lg6eITwYe9v6Hr5CncVbK70SoioNQIq81nsaG86ev5hAidQvmOeETBqs7jm43K2F5/Ley3ytDtriImV6TpNiSg==",
+      "version": "8.4.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.13.tgz",
+      "integrity": "sha512-jtL6eTBrza5MPzy8oJLFuUscHDXTV5KcLlqAWHl5q5WYRfnNRGSmOZmOZ1T6Gy7A99mOZfqungmZMpMmCVJ8ZA==",
       "dev": true,
       "requires": {
-        "nanoid": "^3.3.1",
+        "nanoid": "^3.3.3",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       }
@@ -11917,9 +11949,9 @@
       "requires": {}
     },
     "postcss-custom-properties": {
-      "version": "12.1.5",
-      "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-12.1.5.tgz",
-      "integrity": "sha512-FHbbB/hRo/7cxLGkc2NS7cDRIDN1oFqQnUKBiyh4b/gwk8DD8udvmRDpUhEK836kB8ggUCieHVOvZDnF9XhI3g==",
+      "version": "12.1.7",
+      "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-12.1.7.tgz",
+      "integrity": "sha512-N/hYP5gSoFhaqxi2DPCmvto/ZcRDVjE3T1LiAMzc/bg53hvhcHOLpXOHb526LzBBp5ZlAUhkuot/bfpmpgStJg==",
       "dev": true,
       "requires": {
         "postcss-value-parser": "^4.2.0"
@@ -12011,9 +12043,9 @@
       "requires": {}
     },
     "postcss-lab-function": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-lab-function/-/postcss-lab-function-4.1.2.tgz",
-      "integrity": "sha512-isudf5ldhg4fk16M8viAwAbg6Gv14lVO35N3Z/49NhbwPQ2xbiEoHgrRgpgQojosF4vF7jY653ktB6dDrUOR8Q==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-lab-function/-/postcss-lab-function-4.2.0.tgz",
+      "integrity": "sha512-Zb1EO9DGYfa3CP8LhINHCcTTCTLI+R3t7AX2mKsDzdgVQ/GkCpHOTgOr6HBHslP7XDdVbqgHW5vvRPMdVANQ8w==",
       "dev": true,
       "requires": {
         "@csstools/postcss-progressive-custom-properties": "^1.1.0",
@@ -12041,12 +12073,12 @@
       "dev": true
     },
     "postcss-nesting": {
-      "version": "10.1.3",
-      "resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-10.1.3.tgz",
-      "integrity": "sha512-wUC+/YCik4wH3StsbC5fBG1s2Z3ZV74vjGqBFYtmYKlVxoio5TYGM06AiaKkQPPlkXWn72HKfS7Cw5PYxnoXSw==",
+      "version": "10.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-10.1.4.tgz",
+      "integrity": "sha512-2ixdQ59ik/Gt1+oPHiI1kHdwEI8lLKEmui9B1nl6163ANLC+GewQn7fXMxJF2JSb4i2MKL96GU8fIiQztK4TTA==",
       "dev": true,
       "requires": {
-        "postcss-selector-parser": "^6.0.9"
+        "postcss-selector-parser": "^6.0.10"
       }
     },
     "postcss-opacity-percentage": {
@@ -12079,21 +12111,21 @@
       }
     },
     "postcss-preset-env": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-7.4.3.tgz",
-      "integrity": "sha512-dlPA65g9KuGv7YsmGyCKtFkZKCPLkoVMUE3omOl6yM+qrynVHxFvf0tMuippIrXB/sB/MyhL1FgTIbrO+qMERg==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-7.4.4.tgz",
+      "integrity": "sha512-MqzSEx/QsvOk562iV9mLTgIvLFEOq1os9QBQfkgnq8TW6yKhVFPGh0gdXSK5ZlmjuNQEga6/x833e86XZF/lug==",
       "dev": true,
       "requires": {
-        "@csstools/postcss-color-function": "^1.0.3",
+        "@csstools/postcss-color-function": "^1.1.0",
         "@csstools/postcss-font-format-keywords": "^1.0.0",
         "@csstools/postcss-hwb-function": "^1.0.0",
         "@csstools/postcss-ic-unit": "^1.0.0",
-        "@csstools/postcss-is-pseudo-class": "^2.0.1",
+        "@csstools/postcss-is-pseudo-class": "^2.0.2",
         "@csstools/postcss-normalize-display-values": "^1.0.0",
-        "@csstools/postcss-oklab-function": "^1.0.2",
+        "@csstools/postcss-oklab-function": "^1.1.0",
         "@csstools/postcss-progressive-custom-properties": "^1.3.0",
-        "autoprefixer": "^10.4.4",
-        "browserslist": "^4.20.2",
+        "autoprefixer": "^10.4.5",
+        "browserslist": "^4.20.3",
         "css-blank-pseudo": "^3.0.3",
         "css-has-pseudo": "^3.0.4",
         "css-prefers-color-scheme": "^6.0.3",
@@ -12104,7 +12136,7 @@
         "postcss-color-hex-alpha": "^8.0.3",
         "postcss-color-rebeccapurple": "^7.0.2",
         "postcss-custom-media": "^8.0.0",
-        "postcss-custom-properties": "^12.1.5",
+        "postcss-custom-properties": "^12.1.7",
         "postcss-custom-selectors": "^6.0.0",
         "postcss-dir-pseudo-class": "^6.0.4",
         "postcss-double-position-gradients": "^3.1.1",
@@ -12115,27 +12147,27 @@
         "postcss-gap-properties": "^3.0.3",
         "postcss-image-set-function": "^4.0.6",
         "postcss-initial": "^4.0.1",
-        "postcss-lab-function": "^4.1.2",
+        "postcss-lab-function": "^4.2.0",
         "postcss-logical": "^5.0.4",
         "postcss-media-minmax": "^5.0.0",
-        "postcss-nesting": "^10.1.3",
+        "postcss-nesting": "^10.1.4",
         "postcss-opacity-percentage": "^1.1.2",
         "postcss-overflow-shorthand": "^3.0.3",
         "postcss-page-break": "^3.0.4",
         "postcss-place": "^7.0.4",
-        "postcss-pseudo-class-any-link": "^7.1.1",
+        "postcss-pseudo-class-any-link": "^7.1.2",
         "postcss-replace-overflow-wrap": "^4.0.0",
         "postcss-selector-not": "^5.0.0",
         "postcss-value-parser": "^4.2.0"
       }
     },
     "postcss-pseudo-class-any-link": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-7.1.1.tgz",
-      "integrity": "sha512-JRoLFvPEX/1YTPxRxp1JO4WxBVXJYrSY7NHeak5LImwJ+VobFMwYDQHvfTXEpcn+7fYIeGkC29zYFhFWIZD8fg==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-7.1.2.tgz",
+      "integrity": "sha512-76XzEQv3g+Vgnz3tmqh3pqQyRojkcJ+pjaePsyhcyf164p9aZsu3t+NWxkZYbcHLK1ju5Qmalti2jPI5IWCe5w==",
       "dev": true,
       "requires": {
-        "postcss-selector-parser": "^6.0.9"
+        "postcss-selector-parser": "^6.0.10"
       }
     },
     "postcss-replace-overflow-wrap": {
@@ -12977,9 +13009,9 @@
       }
     },
     "stylelint": {
-      "version": "14.7.1",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.7.1.tgz",
-      "integrity": "sha512-rUOWm67hrzGXXyO/cInENEejF4urh1dLgOb9cr/3XLDb/t/A+rXQp3p6+no8o8QCKTgBUdhVUq/bXMgE988PJw==",
+      "version": "14.8.1",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.8.1.tgz",
+      "integrity": "sha512-0YxTop3wTeEVmQWhS7jjLFaBkvfPmffRiJ6eFIDlK++f3OklaobTYFJu32E5u/cIrFLbcW52pLqrYpihA/y0/w==",
       "dev": true,
       "requires": {
         "balanced-match": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -40,16 +40,16 @@
   },
   "devDependencies": {
     "@astropub/webapi": "^0.10.14",
-    "@mdn/browser-compat-data": "^4.1.17",
+    "@mdn/browser-compat-data": "^4.1.18",
     "astro": "0.24.3",
     "browserslist": "^4.20.3",
-    "caniuse-lite": "^1.0.30001332",
+    "caniuse-lite": "^1.0.30001334",
     "fse": "^4.0.1",
     "lodash.get": "^4.4.2",
-    "postcss": "^8.4.12",
-    "postcss-preset-env": "^7.4.3",
+    "postcss": "^8.4.13",
+    "postcss-preset-env": "^7.4.4",
     "pre-commit": "^1.2.2",
-    "stylelint": "^14.7.1",
+    "stylelint": "^14.8.1",
     "stylelint-config-standard": "^25.0.0"
   },
   "stylelint": {

--- a/tasks/populate-db.mjs
+++ b/tasks/populate-db.mjs
@@ -10,8 +10,6 @@ const settingsPath = path.resolve(__dirname, '../cssdb.settings.json');
 const cssdb = await fs.readFile(settingsPath, 'utf8').then(JSON.parse);
 
 cssdb.forEach(feature => {
-	feature.browser_support = {};
-
 	if (feature.caniuse) {
 		feature.browser_support = supportedBrowsersFromCanIUse(feature.caniuse, feature);
 	} else if (feature.mdn_path) {


### PR DESCRIPTION
This adds support for

* Exponential Functions (`pow()`, `sqrt()`, `hypot()`, `log()`, `exp()`):  https://www.w3.org/TR/css-values-4/#exponent-funcs
* `calc()` constants (`e`, `pi`, `infinity`, `-infinity` and `NaN`) https://www.w3.org/TR/css-values-4/#calc-constants
* Sign functions (`abs()` and `sign()`): https://www.w3.org/TR/css-values-4/#sign-funcs
* Trigonometric functions (`sin()`, `cos()`, `tan()`, `asin()`, `acos()`, `atan()` and `atan2()`): https://www.w3.org/TR/css-values-4/#trig-funcs

Needed for https://github.com/csstools/postcss-plugins/pull/356

It also allows to manually override support for things that aren't yet on MDN nor Can I Use