### PR TITLE
fix old badge urls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ gh-pages
 node_modules
 dist
 public/images/badges
+public/badge

--- a/tasks/write-badges.js
+++ b/tasks/write-badges.js
@@ -5,6 +5,7 @@ polyfill(globalThis);
 
 const cssdbJsonURL = new URL('../cssdb.json', import.meta.url);
 const badgesDirURL = new URL('../public/images/badges/', import.meta.url);
+const badgesDirURLOld = new URL('../public/badge/', import.meta.url);
 
 const features = await fs.readFile(cssdbJsonURL, 'utf8').then(JSON.parse);
 
@@ -17,8 +18,10 @@ const colors = [
 ];
 
 await fs.rm(badgesDirURL, { force: true, recursive: true });
-
 await fs.mkdir(badgesDirURL);
+
+await fs.rm(badgesDirURLOld, { force: true, recursive: true });
+await fs.mkdir(badgesDirURLOld);
 
 const shieldSubject = 'cssdb';
 
@@ -29,8 +32,12 @@ await Promise.all(features.map(async feature => {
 	const shield = await fetch(shieldUrl).then(response => response.text());
 
 	const badgeURL = new URL(`../public/images/badges/${feature.id}.svg`, import.meta.url);
+	const badgeURLOld = new URL(`../public/badge/${feature.id}.svg`, import.meta.url);
 
-	return fs.writeFile(badgeURL, shield);
+	return Promise.all([
+		fs.writeFile(badgeURL, shield),
+		fs.writeFile(badgeURLOld, shield)
+	]);
 }));
 
 process.exit(0);


### PR DESCRIPTION
see : https://github.com/postcss/postcss-media-minmax/blob/master/README.md

<img width="677" alt="Screenshot 2022-08-14 at 18 01 05" src="https://user-images.githubusercontent.com/11521496/184545184-2a5ad367-9cd4-4ef5-8dab-be88db2a4ff0.png">


Fixing these is low effort and makes every plugin using these look a bit neater without requiring updates on their end.