### PR TITLE
`media-queries-aspect-ratio-number-values`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ### Unreleased
 
 - Added: Stage 2 `media-queries-aspect-ratio-number-values`
-- Updated `@mdn/browser-compat-data` to `5.2.15` (patch)
-- Updated `caniuse-lite` to `1.0.30001431` (patch)
+- Updated `@mdn/browser-compat-data` to `5.2.19` (patch)
+- Updated `caniuse-lite` to `1.0.30001434` (patch)
 
 ### 7.1.0 (November 4, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to cssdb
 
+### Unreleased
+
+- Added: Stage 2 `media-queries-aspect-ratio-number-values`
+
 ### 7.1.0 (November 4, 2022)
 
 - Added: Stage 2 `scope-pseudo-class`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### Unreleased
 
 - Added: Stage 2 `media-queries-aspect-ratio-number-values`
+- Updated `@mdn/browser-compat-data` to `5.2.15` (patch)
+- Updated `caniuse-lite` to `1.0.30001431` (patch)
 
 ### 7.1.0 (November 4, 2022)
 

--- a/cssdb.json
+++ b/cssdb.json
@@ -64,6 +64,25 @@
     "vendors_implementations": 3
   },
   {
+    "id": "media-queries-aspect-ratio-number-values",
+    "title": "Aspect-Ratio number values",
+    "description": "Support `<ratio>` values with `<number>` components in `@media`",
+    "specification": "https://www.w3.org/TR/css-values-4/#ratio-value",
+    "stage": 2,
+    "browser_support": {},
+    "docs": {
+      "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/ratio"
+    },
+    "example": "@media (device-aspect-ratio: 1.77) {\n  html {\n    background-color: cyan;\n  }\n}",
+    "polyfills": [
+      {
+        "type": "PostCSS Plugin",
+        "link": "https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-media-queries-aspect-ratio-number-values"
+      }
+    ],
+    "vendors_implementations": 0
+  },
+  {
     "id": "blank-pseudo-class",
     "title": "`:blank` Empty-Value Pseudo-Class",
     "description": "A pseudo-class for matching form elements when they are empty",

--- a/cssdb.json
+++ b/cssdb.json
@@ -73,7 +73,7 @@
     "docs": {
       "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/ratio"
     },
-    "example": "@media (device-aspect-ratio: 1.77) {\n  html {\n    background-color: cyan;\n  }\n}",
+    "example": "@media (aspect-ratio: 1.77) {\n  html {\n    background-color: cyan;\n  }\n}",
     "polyfills": [
       {
         "type": "PostCSS Plugin",

--- a/cssdb.mjs
+++ b/cssdb.mjs
@@ -73,7 +73,7 @@ export default [
     "docs": {
       "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/ratio"
     },
-    "example": "@media (device-aspect-ratio: 1.77) {\n  html {\n    background-color: cyan;\n  }\n}",
+    "example": "@media (aspect-ratio: 1.77) {\n  html {\n    background-color: cyan;\n  }\n}",
     "polyfills": [
       {
         "type": "PostCSS Plugin",

--- a/cssdb.mjs
+++ b/cssdb.mjs
@@ -64,6 +64,25 @@ export default [
     "vendors_implementations": 3
   },
   {
+    "id": "media-queries-aspect-ratio-number-values",
+    "title": "Aspect-Ratio number values",
+    "description": "Support `<ratio>` values with `<number>` components in `@media`",
+    "specification": "https://www.w3.org/TR/css-values-4/#ratio-value",
+    "stage": 2,
+    "browser_support": {},
+    "docs": {
+      "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/ratio"
+    },
+    "example": "@media (device-aspect-ratio: 1.77) {\n  html {\n    background-color: cyan;\n  }\n}",
+    "polyfills": [
+      {
+        "type": "PostCSS Plugin",
+        "link": "https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-media-queries-aspect-ratio-number-values"
+      }
+    ],
+    "vendors_implementations": 0
+  },
+  {
     "id": "blank-pseudo-class",
     "title": "`:blank` Empty-Value Pseudo-Class",
     "description": "A pseudo-class for matching form elements when they are empty",

--- a/cssdb.settings.json
+++ b/cssdb.settings.json
@@ -50,7 +50,7 @@
     "docs": {
       "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/ratio"
     },
-    "example": "@media (device-aspect-ratio: 1.77) {\n  html {\n    background-color: cyan;\n  }\n}",
+    "example": "@media (aspect-ratio: 1.77) {\n  html {\n    background-color: cyan;\n  }\n}",
     "mdn_path": "css.types.ratio.number_value",
     "polyfills": [
       {

--- a/cssdb.settings.json
+++ b/cssdb.settings.json
@@ -41,6 +41,25 @@
     ]
   },
   {
+    "id": "media-queries-aspect-ratio-number-values",
+    "title": "Aspect-Ratio number values",
+    "description": "Support `<ratio>` values with `<number>` components in `@media`",
+    "specification": "https://www.w3.org/TR/css-values-4/#ratio-value",
+    "stage": 2,
+    "browser_support": {},
+    "docs": {
+      "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/ratio"
+    },
+    "example": "@media (device-aspect-ratio: 1.77) {\n  html {\n    background-color: cyan;\n  }\n}",
+    "mdn_path": "css.types.ratio.number_value",
+    "polyfills": [
+      {
+        "type": "PostCSS Plugin",
+        "link": "https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-media-queries-aspect-ratio-number-values"
+      }
+    ]
+  },
+  {
     "id": "blank-pseudo-class",
     "title": "`:blank` Empty-Value Pseudo-Class",
     "description": "A pseudo-class for matching form elements when they are empty",


### PR DESCRIPTION
see : https://github.com/mdn/browser-compat-data/issues/18198

MDN data is currently outdated and no browser seems to support this.
But has been in Firefox since 78.

Weirdly it is supported in the `aspect-ratio` property in all browsers.