### PR TITLE
data for ratio in at-media

### DIFF
--- a/cssdb.json
+++ b/cssdb.json
@@ -1160,7 +1160,16 @@
     "description": "Support `<ratio>` values with `<number>` components in `@media`",
     "specification": "https://www.w3.org/TR/css-values-4/#ratio-value",
     "stage": 2,
-    "browser_support": {},
+    "browser_support": {
+      "and_chr": "110",
+      "and_ff": "78",
+      "android": "110",
+      "chrome": "110",
+      "edge": "110",
+      "firefox": "78",
+      "ios_saf": "16.2",
+      "safari": "16.2"
+    },
     "docs": {
       "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/ratio"
     },
@@ -1171,7 +1180,7 @@
         "link": "https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-media-queries-aspect-ratio-number-values"
       }
     ],
-    "vendors_implementations": 0
+    "vendors_implementations": 2
   },
   {
     "id": "media-query-ranges",

--- a/cssdb.mjs
+++ b/cssdb.mjs
@@ -1160,7 +1160,16 @@ export default [
     "description": "Support `<ratio>` values with `<number>` components in `@media`",
     "specification": "https://www.w3.org/TR/css-values-4/#ratio-value",
     "stage": 2,
-    "browser_support": {},
+    "browser_support": {
+      "and_chr": "110",
+      "and_ff": "78",
+      "android": "110",
+      "chrome": "110",
+      "edge": "110",
+      "firefox": "78",
+      "ios_saf": "16.2",
+      "safari": "16.2"
+    },
     "docs": {
       "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/ratio"
     },
@@ -1171,7 +1180,7 @@ export default [
         "link": "https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-media-queries-aspect-ratio-number-values"
       }
     ],
-    "vendors_implementations": 0
+    "vendors_implementations": 2
   },
   {
     "id": "media-query-ranges",

--- a/cssdb.settings.json
+++ b/cssdb.settings.json
@@ -928,6 +928,48 @@
     "specification": "https://www.w3.org/TR/css-values-4/#ratio-value",
     "stage": 2,
     "browser_support": {},
+    "browser_support_overrides": {
+      "and_chr": {
+        "from": null,
+        "to": "110",
+        "bug": "https://github.com/mdn/browser-compat-data/issues/18198"
+      },
+      "and_ff": {
+        "from": null,
+        "to": "78",
+        "bug": "https://github.com/mdn/browser-compat-data/issues/18198"
+      },
+      "android": {
+        "from": null,
+        "to": "110",
+        "bug": "https://github.com/mdn/browser-compat-data/issues/18198"
+      },
+      "chrome": {
+        "from": null,
+        "to": "110",
+        "bug": "https://github.com/mdn/browser-compat-data/issues/18198"
+      },
+      "edge": {
+        "from": null,
+        "to": "110",
+        "bug": "https://github.com/mdn/browser-compat-data/issues/18198"
+      },
+      "firefox": {
+        "from": null,
+        "to": "78",
+        "bug": "https://github.com/mdn/browser-compat-data/issues/18198"
+      },
+      "ios_saf": {
+        "from": null,
+        "to": "16.2",
+        "bug": "https://github.com/mdn/browser-compat-data/issues/18198"
+      },
+      "safari": {
+        "from": null,
+        "to": "16.2",
+        "bug": "https://github.com/mdn/browser-compat-data/issues/18198"
+      }
+    },
     "docs": {
       "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/ratio"
     },
@@ -1268,7 +1310,7 @@
       }
     ]
   },
-    {
+  {
     "id": "text-decoration-shorthand",
     "title": "`text-decoration` shorthand",
     "description": "A property for defining `text-decoration-line`, `text-decoration-thickness`, `text-decoration-style` and `text-decoration-color`",


### PR DESCRIPTION
MDN hasn't yet updated their tracking of this sub feature.
Adding data manually as a workaround.