### PR TITLE
fix a tiny bug in the site

### DIFF
--- a/src/components/feature-polyfills.mjs
+++ b/src/components/feature-polyfills.mjs
@@ -12,7 +12,7 @@ export function renderFeaturePolyfills(polyfills, id, title) {
 			<ul class="cssdb-feature-polyfill-list">
 				${polyfills.map(polyfill => {
 					return renderFeaturePolyfill(polyfill, id, title);
-				})}
+				}).join('')}
 			</ul>
 		</div>
 	`;


### PR DESCRIPTION
This `,` is not supposed to be there.

<img width="575" alt="Screenshot 2023-03-24 at 18 32 01" src="https://user-images.githubusercontent.com/11521496/227598774-386defb9-81d6-4b61-a6c7-f43f6fe15064.png">
