### PR TITLE
update support data for media-query-ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to cssdb
 
+### Unreleased (patch)
+
+- Updated support data for `media-query-ranges`
+
 ### 7.5.2 (March 28, 2023)
 
 - Updated support data for `color-mix`

--- a/cssdb.json
+++ b/cssdb.json
@@ -1252,7 +1252,16 @@
     "description": "A syntax for defining media query ranges using ordinary comparison operators",
     "specification": "https://www.w3.org/TR/mediaqueries-4/#range-context",
     "stage": 3,
-    "browser_support": {},
+    "browser_support": {
+      "and_chr": "104",
+      "and_ff": "63",
+      "android": "104",
+      "chrome": "104",
+      "firefox": "63",
+      "oculus": "23.0",
+      "op_mob": "71",
+      "samsung": "20.0"
+    },
     "docs": {
       "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#Syntax_improvements_in_Level_4"
     },
@@ -1263,7 +1272,7 @@
         "link": "https://github.com/postcss/postcss-media-minmax"
       }
     ],
-    "vendors_implementations": 0
+    "vendors_implementations": 2
   },
   {
     "id": "nested-calc",

--- a/cssdb.json
+++ b/cssdb.json
@@ -1244,7 +1244,7 @@
         "link": "https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-media-queries-aspect-ratio-number-values"
       }
     ],
-    "vendors_implementations": 2
+    "vendors_implementations": 3
   },
   {
     "id": "media-query-ranges",

--- a/cssdb.mjs
+++ b/cssdb.mjs
@@ -1252,7 +1252,16 @@ export default [
     "description": "A syntax for defining media query ranges using ordinary comparison operators",
     "specification": "https://www.w3.org/TR/mediaqueries-4/#range-context",
     "stage": 3,
-    "browser_support": {},
+    "browser_support": {
+      "and_chr": "104",
+      "and_ff": "63",
+      "android": "104",
+      "chrome": "104",
+      "firefox": "63",
+      "oculus": "23.0",
+      "op_mob": "71",
+      "samsung": "20.0"
+    },
     "docs": {
       "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#Syntax_improvements_in_Level_4"
     },
@@ -1263,7 +1272,7 @@ export default [
         "link": "https://github.com/postcss/postcss-media-minmax"
       }
     ],
-    "vendors_implementations": 0
+    "vendors_implementations": 2
   },
   {
     "id": "nested-calc",

--- a/cssdb.mjs
+++ b/cssdb.mjs
@@ -1244,7 +1244,7 @@ export default [
         "link": "https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-media-queries-aspect-ratio-number-values"
       }
     ],
-    "vendors_implementations": 2
+    "vendors_implementations": 3
   },
   {
     "id": "media-query-ranges",

--- a/cssdb.settings.json
+++ b/cssdb.settings.json
@@ -1063,6 +1063,7 @@
       "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#Syntax_improvements_in_Level_4"
     },
     "example": "@media (width < 480px) {}\n\n@media (480px <= width < 768px) {}\n\n@media (width >= 768px) {}",
+    "mdn_path": "css.at-rules.media.range_syntax",
     "polyfills": [
       {
         "type": "PostCSS Plugin",

--- a/package-lock.json
+++ b/package-lock.json
@@ -109,9 +109,9 @@
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-1.0.0.tgz",
-      "integrity": "sha512-u3JrK+pQIGGnXe+YhohWwAwOum2y25NRdEjRQFD3moMnOJgmU/nj8BPAF6DDQAooy8Ty9RNKiAh2njuqwMgUNQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-1.1.0.tgz",
+      "integrity": "sha512-jRpIhjThaH8jxuJ8Q1H+jai/dekP5952kzLHTuN+rPI48eF2esf/18TMb3N/HtEgmnybhfiwUO6Ph2OkHi3jpA==",
       "dev": true,
       "dependencies": {
         "@csstools/color-helpers": "^2.0.0",
@@ -246,6 +246,28 @@
       "dev": true,
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/csstools"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/postcss-gradients-interpolation-method": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-gradients-interpolation-method/-/postcss-gradients-interpolation-method-3.0.1.tgz",
+      "integrity": "sha512-sCfFSzL5HRb/GhrGuTEi8IRrxp2bUeKakyXvuXzuBBxL0L2X8kZAljQwkuRkd0W/wIWTsQG/E72REb5XMmRfrA==",
+      "dev": true,
+      "dependencies": {
+        "@csstools/css-color-parser": "^1.1.0",
+        "@csstools/css-parser-algorithms": "^2.1.0",
+        "@csstools/css-tokenizer": "^2.1.0",
+        "@csstools/postcss-progressive-custom-properties": "^2.0.0"
       },
       "engines": {
         "node": "^14 || ^16 || >=18"
@@ -600,9 +622,9 @@
       }
     },
     "node_modules/@mdn/browser-compat-data": {
-      "version": "5.2.45",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.2.45.tgz",
-      "integrity": "sha512-Er03EjYAx3TTMvdBdm6Z3SG4IV0/FWfRJP4CBNtRLWoPVVyp9BdYt/9X4zSFw4GAIOVx6+6r7d8VAw0sbPtMjg==",
+      "version": "5.2.46",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.2.46.tgz",
+      "integrity": "sha512-JykrfkYv6nHbuclWTj3CnLb2wly/hVKeUzLnaLn3eE6lMFeXLmF4L0f60wqHAlGQ4us85abQSPzZrGzTsMGSYA==",
       "dev": true
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -868,9 +890,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001470",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001470.tgz",
-      "integrity": "sha512-065uNwY6QtHCBOExzbV6m236DDhYCCtPmQUCoQtwkVqzud8v5QPidoMr6CoMkC2nfp6nksjttqWQRRh75LqUmA==",
+      "version": "1.0.30001472",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001472.tgz",
+      "integrity": "sha512-xWC/0+hHHQgj3/vrKYY0AAzeIUgr7L9wlELIcAvZdDUHlhL/kNxMdnQLOSOQfP8R51ZzPhmHdyMkI0MMpmxCfg==",
       "dev": true,
       "funding": [
         {
@@ -880,6 +902,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },
@@ -1062,9 +1088,9 @@
       }
     },
     "node_modules/cssdb": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-7.5.1.tgz",
-      "integrity": "sha512-YdmjGmoS9TT5wgoKjySaBqgbPYtyxbbegeK8WNqWbZRa7SJcX9V0qGfDjbI8oPQwmh/zuA6ZSnQBCKLj9bZufw==",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-7.5.2.tgz",
+      "integrity": "sha512-Xpu7Bf5Vlw+G7ikA2Lg/lVCRTSY8D5M5qFUgGNFyS4pa8ufGLyCBxIX/3if3krHlF1SKSfVPI/YsAWLDVEbocw==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -1156,9 +1182,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.340",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.340.tgz",
-      "integrity": "sha512-zx8hqumOqltKsv/MF50yvdAlPF9S/4PXbyfzJS6ZGhbddGkRegdwImmfSVqCkEziYzrIGZ/TlrzBND4FysfkDg==",
+      "version": "1.4.342",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.342.tgz",
+      "integrity": "sha512-dTei3VResi5bINDENswBxhL+N0Mw5YnfWyTqO75KGsVldurEkhC9+CelJVAse8jycWyP8pv3VSj4BSyP8wTWJA==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -2665,15 +2691,16 @@
       }
     },
     "node_modules/postcss-preset-env": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-8.1.0.tgz",
-      "integrity": "sha512-YIsPebk8tMZ9dOcKynyDue5zaod1oyXQ7WhbjmTufjNf9RyJlJx0A/4jYLVKxaHL8XgeygoUghg99+vwPX4SFA==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-8.2.0.tgz",
+      "integrity": "sha512-m5wWWANGQlXFYpgIcuatUWXYFQDhSfxeet4RiwietcuDpnXWpkY9JbzegR73DP0V6MUbhiIIl0vVjfJyql+Esw==",
       "dev": true,
       "dependencies": {
         "@csstools/postcss-cascade-layers": "^3.0.1",
         "@csstools/postcss-color-function": "^2.1.0",
         "@csstools/postcss-color-mix-function": "^1.0.0",
         "@csstools/postcss-font-format-keywords": "^2.0.2",
+        "@csstools/postcss-gradients-interpolation-method": "^3.0.1",
         "@csstools/postcss-hwb-function": "^2.2.0",
         "@csstools/postcss-ic-unit": "^2.0.2",
         "@csstools/postcss-is-pseudo-class": "^3.1.1",
@@ -2695,7 +2722,7 @@
         "css-blank-pseudo": "^5.0.2",
         "css-has-pseudo": "^5.0.2",
         "css-prefers-color-scheme": "^8.0.2",
-        "cssdb": "^7.5.1",
+        "cssdb": "^7.5.2",
         "postcss-attribute-case-insensitive": "^6.0.2",
         "postcss-clamp": "^4.1.0",
         "postcss-color-functional-notation": "^5.0.2",
@@ -3807,9 +3834,9 @@
       "requires": {}
     },
     "@csstools/css-color-parser": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-1.0.0.tgz",
-      "integrity": "sha512-u3JrK+pQIGGnXe+YhohWwAwOum2y25NRdEjRQFD3moMnOJgmU/nj8BPAF6DDQAooy8Ty9RNKiAh2njuqwMgUNQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-1.1.0.tgz",
+      "integrity": "sha512-jRpIhjThaH8jxuJ8Q1H+jai/dekP5952kzLHTuN+rPI48eF2esf/18TMb3N/HtEgmnybhfiwUO6Ph2OkHi3jpA==",
       "dev": true,
       "requires": {
         "@csstools/color-helpers": "^2.0.0",
@@ -3877,6 +3904,18 @@
       "dev": true,
       "requires": {
         "postcss-value-parser": "^4.2.0"
+      }
+    },
+    "@csstools/postcss-gradients-interpolation-method": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-gradients-interpolation-method/-/postcss-gradients-interpolation-method-3.0.1.tgz",
+      "integrity": "sha512-sCfFSzL5HRb/GhrGuTEi8IRrxp2bUeKakyXvuXzuBBxL0L2X8kZAljQwkuRkd0W/wIWTsQG/E72REb5XMmRfrA==",
+      "dev": true,
+      "requires": {
+        "@csstools/css-color-parser": "^1.1.0",
+        "@csstools/css-parser-algorithms": "^2.1.0",
+        "@csstools/css-tokenizer": "^2.1.0",
+        "@csstools/postcss-progressive-custom-properties": "^2.0.0"
       }
     },
     "@csstools/postcss-hwb-function": {
@@ -4049,9 +4088,9 @@
       "requires": {}
     },
     "@mdn/browser-compat-data": {
-      "version": "5.2.45",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.2.45.tgz",
-      "integrity": "sha512-Er03EjYAx3TTMvdBdm6Z3SG4IV0/FWfRJP4CBNtRLWoPVVyp9BdYt/9X4zSFw4GAIOVx6+6r7d8VAw0sbPtMjg==",
+      "version": "5.2.46",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.2.46.tgz",
+      "integrity": "sha512-JykrfkYv6nHbuclWTj3CnLb2wly/hVKeUzLnaLn3eE6lMFeXLmF4L0f60wqHAlGQ4us85abQSPzZrGzTsMGSYA==",
       "dev": true
     },
     "@nodelib/fs.scandir": {
@@ -4233,9 +4272,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001470",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001470.tgz",
-      "integrity": "sha512-065uNwY6QtHCBOExzbV6m236DDhYCCtPmQUCoQtwkVqzud8v5QPidoMr6CoMkC2nfp6nksjttqWQRRh75LqUmA==",
+      "version": "1.0.30001472",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001472.tgz",
+      "integrity": "sha512-xWC/0+hHHQgj3/vrKYY0AAzeIUgr7L9wlELIcAvZdDUHlhL/kNxMdnQLOSOQfP8R51ZzPhmHdyMkI0MMpmxCfg==",
       "dev": true
     },
     "chalk": {
@@ -4359,9 +4398,9 @@
       }
     },
     "cssdb": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-7.5.1.tgz",
-      "integrity": "sha512-YdmjGmoS9TT5wgoKjySaBqgbPYtyxbbegeK8WNqWbZRa7SJcX9V0qGfDjbI8oPQwmh/zuA6ZSnQBCKLj9bZufw==",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-7.5.2.tgz",
+      "integrity": "sha512-Xpu7Bf5Vlw+G7ikA2Lg/lVCRTSY8D5M5qFUgGNFyS4pa8ufGLyCBxIX/3if3krHlF1SKSfVPI/YsAWLDVEbocw==",
       "dev": true
     },
     "cssesc": {
@@ -4419,9 +4458,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.340",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.340.tgz",
-      "integrity": "sha512-zx8hqumOqltKsv/MF50yvdAlPF9S/4PXbyfzJS6ZGhbddGkRegdwImmfSVqCkEziYzrIGZ/TlrzBND4FysfkDg==",
+      "version": "1.4.342",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.342.tgz",
+      "integrity": "sha512-dTei3VResi5bINDENswBxhL+N0Mw5YnfWyTqO75KGsVldurEkhC9+CelJVAse8jycWyP8pv3VSj4BSyP8wTWJA==",
       "dev": true
     },
     "emoji-regex": {
@@ -5419,15 +5458,16 @@
       }
     },
     "postcss-preset-env": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-8.1.0.tgz",
-      "integrity": "sha512-YIsPebk8tMZ9dOcKynyDue5zaod1oyXQ7WhbjmTufjNf9RyJlJx0A/4jYLVKxaHL8XgeygoUghg99+vwPX4SFA==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-8.2.0.tgz",
+      "integrity": "sha512-m5wWWANGQlXFYpgIcuatUWXYFQDhSfxeet4RiwietcuDpnXWpkY9JbzegR73DP0V6MUbhiIIl0vVjfJyql+Esw==",
       "dev": true,
       "requires": {
         "@csstools/postcss-cascade-layers": "^3.0.1",
         "@csstools/postcss-color-function": "^2.1.0",
         "@csstools/postcss-color-mix-function": "^1.0.0",
         "@csstools/postcss-font-format-keywords": "^2.0.2",
+        "@csstools/postcss-gradients-interpolation-method": "^3.0.1",
         "@csstools/postcss-hwb-function": "^2.2.0",
         "@csstools/postcss-ic-unit": "^2.0.2",
         "@csstools/postcss-is-pseudo-class": "^3.1.1",
@@ -5449,7 +5489,7 @@
         "css-blank-pseudo": "^5.0.2",
         "css-has-pseudo": "^5.0.2",
         "css-prefers-color-scheme": "^8.0.2",
-        "cssdb": "^7.5.1",
+        "cssdb": "^7.5.2",
         "postcss-attribute-case-insensitive": "^6.0.2",
         "postcss-clamp": "^4.1.0",
         "postcss-color-functional-notation": "^5.0.2",


### PR DESCRIPTION
We initially removed this because the firefox data is likely incorrect.
But I suggest we add it back given that Chrome and Safari shipped.

It is highly unlikely that anyone is targeting only old firefox and really needs to support a specific old firefox version while at the same time using this particular feature in a specific way that they encounter one of the bugs. So I don't think anyone will be affected by this issue.

More people will be affected from the plugin not being enabled (number of implementations) or by the plugin always transforming (targeting modern browsers)