### PR TITLE
more accurate data for `media-query-ranges`

### DIFF
--- a/cssdb.json
+++ b/cssdb.json
@@ -1254,13 +1254,15 @@
     "stage": 3,
     "browser_support": {
       "and_chr": "104",
-      "and_ff": "63",
+      "and_ff": "102",
       "android": "104",
       "chrome": "104",
-      "firefox": "63",
+      "firefox": "102",
       "oculus": "23.0",
       "op_mob": "71",
-      "samsung": "20.0"
+      "samsung": "20.0",
+      "ios_saf": "16.4",
+      "safari": "16.4"
     },
     "docs": {
       "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#Syntax_improvements_in_Level_4"
@@ -1272,7 +1274,7 @@
         "link": "https://github.com/postcss/postcss-media-minmax"
       }
     ],
-    "vendors_implementations": 2
+    "vendors_implementations": 3
   },
   {
     "id": "nested-calc",

--- a/cssdb.mjs
+++ b/cssdb.mjs
@@ -1254,13 +1254,15 @@ export default [
     "stage": 3,
     "browser_support": {
       "and_chr": "104",
-      "and_ff": "63",
+      "and_ff": "102",
       "android": "104",
       "chrome": "104",
-      "firefox": "63",
+      "firefox": "102",
       "oculus": "23.0",
       "op_mob": "71",
-      "samsung": "20.0"
+      "samsung": "20.0",
+      "ios_saf": "16.4",
+      "safari": "16.4"
     },
     "docs": {
       "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#Syntax_improvements_in_Level_4"
@@ -1272,7 +1274,7 @@ export default [
         "link": "https://github.com/postcss/postcss-media-minmax"
       }
     ],
-    "vendors_implementations": 2
+    "vendors_implementations": 3
   },
   {
     "id": "nested-calc",

--- a/cssdb.settings.json
+++ b/cssdb.settings.json
@@ -1059,6 +1059,28 @@
     "specification": "https://www.w3.org/TR/mediaqueries-4/#range-context",
     "stage": 3,
     "browser_support": {},
+    "browser_support_overrides": {
+      "and_ff": {
+        "from": "63",
+        "to": "102",
+        "bug": "https://github.com/mdn/browser-compat-data/pull/19284"
+      },
+      "firefox": {
+        "from": "63",
+        "to": "102",
+        "bug": "https://github.com/mdn/browser-compat-data/pull/19284"
+      },
+      "ios_saf": {
+        "from": null,
+        "to": "16.4",
+        "bug": "https://github.com/mdn/browser-compat-data/pull/19284"
+      },
+      "safari": {
+        "from": null,
+        "to": "16.4",
+        "bug": "https://github.com/mdn/browser-compat-data/pull/19284"
+      }
+    },
     "docs": {
       "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#Syntax_improvements_in_Level_4"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -890,9 +890,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001472",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001472.tgz",
-      "integrity": "sha512-xWC/0+hHHQgj3/vrKYY0AAzeIUgr7L9wlELIcAvZdDUHlhL/kNxMdnQLOSOQfP8R51ZzPhmHdyMkI0MMpmxCfg==",
+      "version": "1.0.30001473",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001473.tgz",
+      "integrity": "sha512-ewDad7+D2vlyy+E4UJuVfiBsU69IL+8oVmTuZnH5Q6CIUbxNfI50uVpRHbUPDD6SUaN2o0Lh4DhTrvLG/Tn1yg==",
       "dev": true,
       "funding": [
         {
@@ -1182,9 +1182,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.342",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.342.tgz",
-      "integrity": "sha512-dTei3VResi5bINDENswBxhL+N0Mw5YnfWyTqO75KGsVldurEkhC9+CelJVAse8jycWyP8pv3VSj4BSyP8wTWJA==",
+      "version": "1.4.347",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.347.tgz",
+      "integrity": "sha512-LNi3+/9nV0vT6Bz1OsSoZ/w7IgNuWdefZ7mjKNjZxyRlI/ag6uMXxsxAy5Etvuixq3Q26exw2fc4bNYvYQqXSw==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -4272,9 +4272,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001472",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001472.tgz",
-      "integrity": "sha512-xWC/0+hHHQgj3/vrKYY0AAzeIUgr7L9wlELIcAvZdDUHlhL/kNxMdnQLOSOQfP8R51ZzPhmHdyMkI0MMpmxCfg==",
+      "version": "1.0.30001473",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001473.tgz",
+      "integrity": "sha512-ewDad7+D2vlyy+E4UJuVfiBsU69IL+8oVmTuZnH5Q6CIUbxNfI50uVpRHbUPDD6SUaN2o0Lh4DhTrvLG/Tn1yg==",
       "dev": true
     },
     "chalk": {
@@ -4458,9 +4458,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.342",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.342.tgz",
-      "integrity": "sha512-dTei3VResi5bINDENswBxhL+N0Mw5YnfWyTqO75KGsVldurEkhC9+CelJVAse8jycWyP8pv3VSj4BSyP8wTWJA==",
+      "version": "1.4.347",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.347.tgz",
+      "integrity": "sha512-LNi3+/9nV0vT6Bz1OsSoZ/w7IgNuWdefZ7mjKNjZxyRlI/ag6uMXxsxAy5Etvuixq3Q26exw2fc4bNYvYQqXSw==",
       "dev": true
     },
     "emoji-regex": {


### PR DESCRIPTION
Glad that I checked this :)

I somehow assumed that Firefox only had a short window where it had a partial implementation. But in reality it only shipped the full feature very recently.

https://github.com/mdn/browser-compat-data/issues/14593#issuecomment-1491436872